### PR TITLE
Feature/1 consolidate demo repos and add ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,25 +103,25 @@ jobs:
     environment:
       PYTHON: 2.7.15
       HOMEBREW_NO_AUTO_UPDATE: 1
-#
+
 #  test-doctest:
 #    docker:
 #      - image: circleci/python:3.5-jessie
-
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-
+#
+#    working_directory: ~/repo
+#
+#    steps:
+#      - checkout
+#
 #      - restore_cache:
 #          keys:
 #          - v1-dependencies-{{ checksum "docs/requirements.txt" }}-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
 #
-      - run:
-          name: install dependencies
-          command: |
-            python -m virtualenv env
-            . env/bin/activate
+#      - run:
+#          name: install dependencies
+#          command: |
+#            python -m virtualenv env
+#            . env/bin/activate
 #            pip install -r docs/requirements.txt
 
 #      - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,17 +10,7 @@ jobs:
     steps:
       - checkout
 
-      # Factoring demo
-#      - run: &make-virtualenv
-#          command: |
-#            python -m virtualenv env
-#
-#      - run:
-#          command: |
-#            . env/bin/activate
-#            pip install -r factoring/requirements_tests.txt
-#
-#TODO: add caching back in, maybe use loop
+      #TODO: add caching once demos share the same requirements file and can live in the same venv
       - run:
           command: |
             demos=$(ls -d */ | grep -v "tests" | grep -v "circuit-fault-diagnosis" | sed 's/\///')
@@ -33,37 +23,6 @@ jobs:
                 coverage run -m unittest discover
                 deactivate
             done
-
-#      - run: &run-tests-template
-#          name: run tests
-#          command: |
-#            . env/bin/activate
-#            coverage run -m unittest discover
-#            deactivate
-
-#      # Qboost demo
-#      - run: *make-virtualenv
-#      - run:
-#          command: |
-#            . env/bin/activate
-#            pip install -r qboost/requirements_tests.txt
-#      - run: *run-tests-template
-#
-#      # Structural Imbalance demo
-#      - run: *make-virtualenv
-#      - run:
-#          command: |
-#            . env/bin/activate
-#            pip install -r structural-imbalance-demo/requirements_tests.txt
-#      - run: *run-tests-template
-#
-      # Circuit Fault Diagnosis demo
-      #- run: *make-virtualenv
-      #- run:
-      #    command: |
-      #      . env/bin/activate
-      #      pip install -r circuit-fault-diagnosis/requirements_tests.txt
-      #- run: *run-tests-template
 
   test-3.6:
     <<: *full-test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       #TODO: add caching once demos share the same requirements file and can live in the same venv
       - run:
           command: |
-            demos=$(ls -d */ | grep -v "tests" | grep -v "circuit-fault-diagnosis" | sed 's/\///')
+            demos=$(ls -d */ | grep -v "tests" | grep -v "circuit-fault-diagnosis" | grep -v "qboost" | sed 's/\///')
             for demo in $demos
             do
                 env="${demo}_env"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       #TODO: add caching once demos share the same requirements file and can live in the same venv
       - run:
           command: |
-            demos=$(ls -d */ | grep -v "tests" | grep -v "circuit-fault-diagnosis" | grep -v "qboost" | sed 's/\///')
+            demos=$(ls -d */ | grep -v "tests" | grep -v "circuit-fault-diagnosis" | sed 's/\///')
             for demo in $demos
             do
                 env="${demo}_env"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,6 @@ jobs:
     docker:
       - image: circleci/python:3.5-jessie
 
-  test-3.4:
-    <<: *full-test-template
-    docker:
-      - image: circleci/python:3.4-jessie
-
   test-2.7:
     <<: *full-test-template
     docker:
@@ -113,12 +108,6 @@ jobs:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.5.5
-      HOMEBREW_NO_AUTO_UPDATE: 1
-
-  test-osx-3.4:
-    <<: *osx-tests-template
-    environment:
-      PYTHON: 3.4.8
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   test-osx-2.7:
@@ -215,12 +204,10 @@ workflows:
       - test-3.7
       - test-3.6
       - test-3.5
-      - test-3.4
       - test-2.7
       - test-osx-3.7
       - test-osx-3.6
       - test-osx-3.5
-      - test-osx-3.4
       - test-osx-2.7
 #      - test-doctest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run:
           name: install dependences and run tests
           command: |
-            for demo in !(tests|circuit-fault-diagnosis); do
+            for demo in ! (tests|circuit-fault-diagnosis); do
               if [ -d "$demo" ]; then
                 env=""$demo"_env"
                 python -m virtualenv "$env"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - checkout
 
       #TODO: add caching once demos share the same requirements file and can live in the same venv
-      - run:
+      - run: &install-and-test-template
           name: install dependences and run tests
           command: |
             shopt -s extglob
@@ -75,19 +75,7 @@ jobs:
             pyenv local $PYTHON
             python -m pip install virtualenv
 
-      - run:
-          name: install dependencies and run tests
-          command: |
-            demos=$(ls -d */ | grep -v "tests" | grep -v "circuit-fault-diagnosis" | sed 's/\///')
-            for demo in $demos
-            do
-                env="${demo}_env"
-                python -m virtualenv $env
-                . $env/bin/activate
-                pip install -r $demo/requirements_tests.txt
-                coverage run -m unittest discover
-                deactivate
-            done
+      - run: *install-and-test-template
 
 #      - run: *codecov-template
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,7 @@ jobs:
 
             for demo in !(tests|circuit-fault-diagnosis); do
               if [ -d "$demo" ]; then
-                env="env_$demo"
-
+                env="envs/$demo"
                 python -m virtualenv "$env"
                 . "$env/bin/activate"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,23 @@ jobs:
 
       #TODO: add caching once demos share the same requirements file and can live in the same venv
       - run:
+          name: set shell options
+          command: |
+            shopt -s extglob
+
+      - run:
           name: install dependences and run tests
           command: |
             for demo in ! (tests|circuit-fault-diagnosis); do
               if [ -d "$demo" ]; then
                 env=""$demo"_env"
+
                 python -m virtualenv "$env"
                 . "$env"/bin/activate
+
                 pip install -r "$demo"/requirements_tests.txt
                 coverage run -m unittest discover
+
                 deactivate
               fi
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,15 +14,15 @@ jobs:
       - run:
           name: install dependences and run tests
           command: |
-            demos=$(ls -d */ | grep -v "tests" | grep -v "circuit-fault-diagnosis" | sed 's/\///')
-            for demo in $demos
-            do
-                env="${demo}_env"
-                python -m virtualenv $env
-                . $env/bin/activate
-                pip install -r $demo/requirements_tests.txt
+            for demo in !(tests|circuit-fault-diagnosis); do
+              if [ -d "$demo" ]; then
+                env=""$demo"_env"
+                python -m virtualenv "$env"
+                . "$env"/bin/activate
+                pip install -r "$demo"/requirements_tests.txt
                 coverage run -m unittest discover
                 deactivate
+              fi
             done
 
   test-3.6:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,8 @@ jobs:
       - image: circleci/python:3.5-jessie
 
   test-2.7:
+    # Note: CircleCI's Python 2.7 environment already has virtualenv pre-installed.
+    #   Hence, even though it's Python 2.7, `python -m virtualenv ..` works.
     <<: *full-test-template
     docker:
       - image: circleci/python:2.7-jessie

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
 
       #TODO: add caching once demos share the same requirements file and can live in the same venv
       - run:
+          name: install dependences and run tests
           command: |
             demos=$(ls -d */ | grep -v "tests" | grep -v "circuit-fault-diagnosis" | sed 's/\///')
             for demo in $demos
@@ -56,45 +57,32 @@ jobs:
           command: |
             brew install pyenv
 
-#      - restore_cache:
-#          keys:
-#            - pyenv-{{ .Environment.CIRCLE_JOB }}
-
       - run:
           name: install python
           command: |
             pyenv install $PYTHON -s
 
-#      - save_cache:
-#          paths:
-#            - ~/.pyenv
-#          key: pyenv-{{ .Environment.CIRCLE_JOB }}
-
-#      - restore_cache: *restore-cache-template
-
+      #TODO: add caching back in when demos have the same requirements and exist in the same venv
       - run:
           name: create virtualenv
           command: |
             eval "$(pyenv init -)"
             pyenv local $PYTHON
             python -m pip install virtualenv
-            python -m virtualenv env
 
       - run:
-          name: install dependencies
+          name: install dependencies and run tests
           command: |
-            . env/bin/activate
-            pip install -r requirements_tests.txt
-
-#      - save_cache: *save-cache-template
-
-      - run: &run-tests-template
-          name: run tests
-          command: |
-            . env/bin/activate
-            coverage run -m unittest discover
-            deactivate
-#      - run: *run-tests-template
+            demos=$(ls -d */ | grep -v "tests" | grep -v "circuit-fault-diagnosis" | sed 's/\///')
+            for demo in $demos
+            do
+                env="${demo}_env"
+                python -m virtualenv $env
+                . $env/bin/activate
+                pip install -r $demo/requirements_tests.txt
+                coverage run -m unittest discover
+                deactivate
+            done
 
 #      - run: *codecov-template
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,10 @@ jobs:
 
       #TODO: add caching once demos share the same requirements file and can live in the same venv
       - run:
-          name: set shell options
+          name: install dependences and run tests
           command: |
             shopt -s extglob
 
-      - run:
-          name: install dependences and run tests
-          command: |
             for demo in !(tests|circuit-fault-diagnosis); do
               if [ -d "$demo" ]; then
                 env=""$demo"_env"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - run:
           name: install dependences and run tests
           command: |
-            for demo in ! (tests|circuit-fault-diagnosis); do
+            for demo in !(tests|circuit-fault-diagnosis); do
               if [ -d "$demo" ]; then
                 env=""$demo"_env"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,12 @@ jobs:
 
             for demo in !(tests|circuit-fault-diagnosis); do
               if [ -d "$demo" ]; then
-                env=""$demo"_env"
+                env="env_$demo"
 
                 python -m virtualenv "$env"
-                . "$env"/bin/activate
+                . "$env/bin/activate"
 
-                pip install -r "$demo"/requirements_tests.txt
+                pip install -r "$demo/requirements_tests.txt"
                 coverage run -m unittest discover
 
                 deactivate

--- a/qboost/requirements.txt
+++ b/qboost/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib==2.1.2
 numpy==1.15.1
-pandas==0.19.2
+pandas==0.23.2
 scipy==1.0.0
 scikit-learn==0.19.1
 dwave-system==0.3.2

--- a/qboost/requirements.txt
+++ b/qboost/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib==2.1.2
 numpy==1.15.1
 pandas==0.23.2
-scipy==1.0.0
-scikit-learn==0.19.1
+scipy==1.1.0
+scikit-learn==0.19.2
 dwave-system==0.3.2
 jupyter==1.0.0

--- a/qboost/requirements.txt
+++ b/qboost/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==2.1.2
-numpy==1.14.2
+numpy==1.15.1
 pandas==0.19.2
 scipy==1.0.0
 scikit-learn==0.19.1


### PR DESCRIPTION
Closes #1 

- PR #2 was a first pass at closing issue #1. This PR finishes off what was started in PR #2.
- Updated config so that macOS demo tests are run
- Add tagging from original demos. Note that only factoring and structural imbalance repos had tags, qboost and circuit fault diagnosis do not.
- Remove Python 3.4 tests
- Updated requirements to support Python 3.7