### PR TITLE
Specify that qboost needs QPU

### DIFF
--- a/qboost/demo.ipynb
+++ b/qboost/demo.ipynb
@@ -149,7 +149,7 @@
     "                 }\n",
     "\n",
     "    # define sampler\n",
-    "    dwave_sampler = DWaveSampler()\n",
+    "    dwave_sampler = DWaveSampler(solver={'qpu': True})\n",
     "    emb_sampler = EmbeddingComposite(dwave_sampler)\n",
     "\n",
     "    N_train = len(X_train)\n",

--- a/qboost/demo.py
+++ b/qboost/demo.py
@@ -51,7 +51,7 @@ def train_model(X_train, y_train, X_test, y_test, lmd):
     TREE_DEPTH = 3
 
     # define sampler
-    dwave_sampler = DWaveSampler()
+    dwave_sampler = DWaveSampler(solver={'qpu': True})
     # sa_sampler = micro.dimod.SimulatedAnnealingSampler()
     emb_sampler = EmbeddingComposite(dwave_sampler)
 


### PR DESCRIPTION
CircleCI uses the default solver, c4-sw_optimize. Qboost hasn't been able to embed with this solver and hence, causes the unit tests to fail. By specifying 'qpu':True, we will give Qboost access to the 2000Q