### PR TITLE
Feature/jss readme

### DIFF
--- a/job-shop-scheduling/README.rst
+++ b/job-shop-scheduling/README.rst
@@ -2,14 +2,67 @@ Job Shop Scheduling Demo
 ========================
 A demo on how to optimally schedule jobs using a quantum computer.
 
+Given a set of jobs and a finite number of machines, how should you schedule
+your jobs on those machines such that all your jobs are completed at the
+earliest possible time? This question is the Job Shop Scheduling Problem!
+
+Each of our jobs can be broken down into smaller machine-specific tasks. For
+example, the job of making pancakes can be broken down into several
+machine-specific tasks: mixing ingredients in a *mixer* and cooking the batter
+on the *stove*. There is an order to these tasks (ex. you can't bake the batter
+before you mix the ingredients) and there is a time associated with each task
+(ex. 5 minutes on the mixer, 2 minutes to cook on the stove). Now supposing
+that you have multiple jobs with only a set number of machines, how do we
+schedule our tasks onto those machines so that our jobs complete as early
+as possible?
+
+Here is a breakfast example with making pancakes and frying some eggs:
+
+::
+  {"pancakes": [("mixer", 5), ("stove", 2)],
+   "eggs": [("stove", 3)]}
+
+Bad schedule: make pancakes and then make eggs. Jobs will complete after 10
+minutes (5 + 2 + 3 = 10).
+
+Good schedule: while mixing pancake ingredients, make eggs. Jobs will complete
+after 7 minutes (5 + 2 = 7).
+
+
 Usage
 -----
 
 Code Overview
 -------------
 
+Constraints:
+
+* Each task starts only once
+* Each task within the job must follow a particular order
+* At most, one task can run on a machine at a given time
+* Remove impossible task times
+
 Code Specifics
 --------------
+Inputs
+~~~~~~
+'jobs' dict describes the jobs we're interested in scheduling. Namely, the dict
+key is the name of the job and the dict value is the ordered list of tasks that
+the job must do.
+
+It follows the format:
+
+::
+  {"job_a": [(machine_name, time_duration_on_machine), ..],
+   "job_b": [(some_machine, time_duration_on_machine), ..],
+   ..
+   "job_n": [(machine_name, time_duration_on_machine), ..]}
+
+For example,
+
+::
+  {"pancakes": [("mixer", 5), ("stove", 2)],
+   "eggs": [("stove", 3)]}
 
 
 References

--- a/job-shop-scheduling/README.rst
+++ b/job-shop-scheduling/README.rst
@@ -85,6 +85,34 @@ For example,
   {"pancakes": [("mixer", 5), ("stove", 2)],
    "eggs": [("stove", 3)]}
 
+Comment on ``max_time``
+~~~~~~~~~~~~~~~~~~~~~~~
+In ``demo.py`` and ``job_shop_scheduler.py``, we see a variable called
+``max_time``. It refers to the maximum possible end time in our job shop
+schedule.
+
+Naively, we could set our ``max_time`` to infinity, so that our solver
+would consider all possible schedules with end times from 0 to infinity.
+However, this is a huge space to explore, and makes our BQM unnecessarily
+large and difficult to solve.
+
+Instead, we can apply our knowledge on the *worst possible* schedule scenario
+so that we can put an upper bound on the schedule end times. The worst possible scenario
+is if all job tasks require the same exact machine, hence there is no opportunity
+for parallelization. In this case, the schedule end time is the sum of all
+task durations because that one machine will run those tasks back-to-back. We know
+the optimal schedule for these tasks must finish earlier or at the same time as
+this worst case scenario because these tasks don't necessarily all need to run
+on that one machine; this allows for parallelization and a shorter schedule. Thus,
+by default, the ``max_time`` considered for a schedule is the sum of task durations.
+
+Note that we can lower ``max_time`` so that the solver considers a smaller space
+of schedule solutions. In terms of quantum computing hardware, this means
+using fewer qubits as we are considering over a smaller range of end times
+and thus, fewer possible schedules. This is acceptable so long as the optimal
+schedule has an end time that is less than ``max_time``. Otherwise, no valid
+schedule would be explored as we are considering schedule end times that are
+shorter than that of the optimal schedule.
 
 References
 ----------

--- a/job-shop-scheduling/README.rst
+++ b/job-shop-scheduling/README.rst
@@ -17,8 +17,8 @@ schedule our tasks onto those machines so that our jobs complete as early
 as possible?
 
 Here is a breakfast example with making pancakes and frying some eggs:
-
 ::
+
   {"pancakes": [("mixer", 5), ("stove", 2)],
    "eggs": [("stove", 3)]}
 
@@ -32,9 +32,14 @@ pancakes are being mixed).
 
 Usage
 -----
+To run the demo:
+::
+  python demo.py
 
 Code Overview
 -------------
+Most of the Job Shop Scheduling magic happens in `job_shop_scheduler.py`, so
+the following overview is on that code.
 
 Constraints:
 
@@ -45,6 +50,9 @@ Constraints:
 
 Code Specifics
 --------------
+As mentioned before, core code for Job Shop Scheduling lives in
+`job_shop_scheduler.py`, so the following sections will be describing that code.
+
 Inputs
 ~~~~~~
 'jobs' dict describes the jobs we're interested in scheduling. Namely, the dict
@@ -52,16 +60,16 @@ key is the name of the job and the dict value is the ordered list of tasks that
 the job must do.
 
 It follows the format:
-
 ::
+
   {"job_a": [(machine_name, time_duration_on_machine), ..],
    "job_b": [(some_machine, time_duration_on_machine), ..],
    ..
    "job_n": [(machine_name, time_duration_on_machine), ..]}
 
 For example,
-
 ::
+
   {"pancakes": [("mixer", 5), ("stove", 2)],
    "eggs": [("stove", 3)]}
 

--- a/job-shop-scheduling/README.rst
+++ b/job-shop-scheduling/README.rst
@@ -37,11 +37,11 @@ To run the demo:
 
 Code Overview
 -------------
-Most of the Job Shop Scheduling magic happens in `job_shop_scheduler.py`, so
-the following overview is on that code. (Note: the `job_shop_scheduler` module
-gets imported into `demo.py`.)
+Most of the Job Shop Scheduling magic happens in ``job_shop_scheduler.py``, so
+the following overview is on that code. (Note: the ``job_shop_scheduler``
+module gets imported into ``demo.py``.)
 
-In the `job_shop_scheduler.py`, we describe the Job Shop Scheduling Problem
+In the ``job_shop_scheduler.py``, we describe the Job Shop Scheduling Problem
 with the following constraints:
 
 * Each task starts only once
@@ -57,7 +57,7 @@ scheduled.
 Code Specifics
 --------------
 As mentioned before, the core code for Job Shop Scheduling lives in
-`job_shop_scheduler.py`, so the following sections will be describing that
+``job_shop_scheduler.py``, so the following sections will be describing that
 code.
 
 Input

--- a/job-shop-scheduling/README.rst
+++ b/job-shop-scheduling/README.rst
@@ -26,7 +26,8 @@ Bad schedule: make pancakes and then make eggs. Jobs will complete after 10
 minutes (5 + 2 + 3 = 10).
 
 Good schedule: while mixing pancake ingredients, make eggs. Jobs will complete
-after 7 minutes (5 + 2 = 7).
+after 7 minutes (5 + 2 = 7; making eggs happens during the 5 minutes the
+pancakes are being mixed).
 
 
 Usage

--- a/job-shop-scheduling/README.rst
+++ b/job-shop-scheduling/README.rst
@@ -108,11 +108,12 @@ by default, the ``max_time`` considered for a schedule is the sum of task durati
 
 Note that we can lower ``max_time`` so that the solver considers a smaller space
 of schedule solutions. In terms of quantum computing hardware, this means
-using fewer qubits as we are considering over a smaller range of end times
+using fewer qubits as we are considering a smaller range of end times
 and thus, fewer possible schedules. This is acceptable so long as the optimal
 schedule has an end time that is less than ``max_time``. Otherwise, no valid
 schedule would be explored as we are considering schedule end times that are
-shorter than that of the optimal schedule.
+shorter than that of the optimal schedule (i.e. shortest possible of any valid
+schedule).
 
 References
 ----------

--- a/job-shop-scheduling/README.rst
+++ b/job-shop-scheduling/README.rst
@@ -2,17 +2,18 @@ Job Shop Scheduling Demo
 ========================
 A demo on how to optimally schedule jobs using a quantum computer.
 
-Given a set of jobs and a finite number of machines, how should you schedule
-your jobs on those machines such that all your jobs are completed at the
+Given a set of jobs and a finite number of machines, how should we schedule
+our jobs on those machines such that all our jobs are completed at the
 earliest possible time? This question is the job shop scheduling problem!
 
-Each of our jobs can be broken down into smaller machine-specific tasks. For
+Now let's go over some details about job shop scheduling. Each of our jobs
+can be broken down into smaller machine-specific tasks. For
 example, the job of making pancakes can be broken down into several
 machine-specific tasks: mixing ingredients in a *mixer* and cooking the batter
-on the *stove*. There is an order to these tasks (e.g. you can't bake the batter
-before you mix the ingredients) and there is a time associated with each task
+on the *stove*. There is an order to these tasks (e.g. we can't bake the batter
+before we mix the ingredients) and there is a time associated with each task
 (e.g. 5 minutes on the mixer, 2 minutes to cook on the stove). Given that
-that you have multiple jobs with only a set number of machines, how do we
+that we have multiple jobs with only a set number of machines, how do we
 schedule our tasks onto those machines so that our jobs complete as early
 as possible?
 
@@ -25,10 +26,10 @@ Here is a breakfast example with making pancakes and frying some eggs:
   {"pancakes": [("mixer", 5), ("stove", 2)],
    "eggs": [("stove", 3)]}
 
-Bad schedule: make pancakes and then make eggs. Jobs will complete after 10
+Bad schedule: make pancakes and then make eggs. The jobs complete after 10
 minutes (5 + 2 + 3 = 10).
 
-Good schedule: while mixing pancake ingredients, make eggs. Jobs will complete
+Good schedule: while mixing pancake ingredients, make eggs. The jobs complete
 after 7 minutes (5 + 2 = 7; making eggs happens during the 5 minutes the
 pancakes are being mixed).
 
@@ -52,15 +53,16 @@ with the following constraints:
 * At most, one task can run on a machine at a given time
 * Task times must be possible
 
-Using tools from the D-Wave Ocean, these constraints get converted into a BQM,
-a type of mathematical expression that we can then submit to a solver.
-Afterwards, the solver will return a solution that will indicate the times in
-which tasks should be scheduled.
+Using tools from the D-Wave Ocean, these constraints get converted into a
+`BQM <https://docs.ocean.dwavesys.com/en/latest/glossary.html#glossary>`_,
+a mathematical model that we can then submit to a solver.
+Afterwards, the solver returns a solution that indicates the times in
+which the tasks should be scheduled.
 
 Code Specifics
 --------------
 As mentioned before, the core code for Job Shop Scheduling lives in
-``job_shop_scheduler.py``, so the following sections will be describing that
+``job_shop_scheduler.py``, so the following sections describe that
 code.
 
 Input

--- a/job-shop-scheduling/README.rst
+++ b/job-shop-scheduling/README.rst
@@ -4,14 +4,14 @@ A demo on how to optimally schedule jobs using a quantum computer.
 
 Given a set of jobs and a finite number of machines, how should you schedule
 your jobs on those machines such that all your jobs are completed at the
-earliest possible time? This question is the Job Shop Scheduling Problem!
+earliest possible time? This question is the job shop scheduling problem!
 
 Each of our jobs can be broken down into smaller machine-specific tasks. For
 example, the job of making pancakes can be broken down into several
 machine-specific tasks: mixing ingredients in a *mixer* and cooking the batter
-on the *stove*. There is an order to these tasks (ex. you can't bake the batter
+on the *stove*. There is an order to these tasks (e.g. you can't bake the batter
 before you mix the ingredients) and there is a time associated with each task
-(ex. 5 minutes on the mixer, 2 minutes to cook on the stove). Now supposing
+(e.g. 5 minutes on the mixer, 2 minutes to cook on the stove). Given that
 that you have multiple jobs with only a set number of machines, how do we
 schedule our tasks onto those machines so that our jobs complete as early
 as possible?
@@ -19,7 +19,7 @@ as possible?
 Here is a breakfast example with making pancakes and frying some eggs:
 ::
 
-  # Interpret as
+  # Note that jobs and tasks in this demo are described in the following format:
   # {"job_name": [("machine_name", duration_on_machine), ..], ..}
 
   {"pancakes": [("mixer", 5), ("stove", 2)],
@@ -50,12 +50,12 @@ with the following constraints:
 * Each task starts only once
 * Each task within the job must follow a particular order
 * At most, one task can run on a machine at a given time
-* Remove impossible task times
+* Task times must be possible
 
 Using tools from the D-Wave Ocean, these constraints get converted into a BQM,
-a type of equation that we can then submit to a solver. Afterwards, the solver
-will return a solution that will indicate the times in which tasks should be
-scheduled.
+a type of mathematical expression that we can then submit to a solver.
+Afterwards, the solver will return a solution that will indicate the times in
+which tasks should be scheduled.
 
 Code Specifics
 --------------

--- a/job-shop-scheduling/README.rst
+++ b/job-shop-scheduling/README.rst
@@ -29,7 +29,6 @@ Good schedule: while mixing pancake ingredients, make eggs. Jobs will complete
 after 7 minutes (5 + 2 = 7; making eggs happens during the 5 minutes the
 pancakes are being mixed).
 
-
 Usage
 -----
 To run the demo:
@@ -39,22 +38,30 @@ To run the demo:
 Code Overview
 -------------
 Most of the Job Shop Scheduling magic happens in `job_shop_scheduler.py`, so
-the following overview is on that code.
+the following overview is on that code. (Note: the `job_shop_scheduler` module
+gets imported into `demo.py`.)
 
-Constraints:
+In the `job_shop_scheduler.py`, we describe the Job Shop Scheduling Problem
+with the following constraints:
 
 * Each task starts only once
 * Each task within the job must follow a particular order
 * At most, one task can run on a machine at a given time
 * Remove impossible task times
 
+Using tools from the D-Wave Ocean, these constraints get converted into a BQM,
+a type of equation that we can then submit to a solver. Afterwards, the solver
+will return a solution that will indicate the times in which tasks should be
+scheduled.
+
 Code Specifics
 --------------
-As mentioned before, core code for Job Shop Scheduling lives in
-`job_shop_scheduler.py`, so the following sections will be describing that code.
+As mentioned before, the core code for Job Shop Scheduling lives in
+`job_shop_scheduler.py`, so the following sections will be describing that
+code.
 
-Inputs
-~~~~~~
+Input
+~~~~~
 'jobs' dict describes the jobs we're interested in scheduling. Namely, the dict
 key is the name of the job and the dict value is the ordered list of tasks that
 the job must do.

--- a/job-shop-scheduling/README.rst
+++ b/job-shop-scheduling/README.rst
@@ -1,8 +1,19 @@
-Demo of Job Shop Scheduling
-===========================
+Job Shop Scheduling Demo
+========================
+A demo on how to optimally schedule jobs using a quantum computer.
 
-Further Information
--------------------
+Usage
+-----
+
+Code Overview
+-------------
+
+Code Specifics
+--------------
+
+
+References
+----------
 D. Venturelli, D. Marchand, and G. Rojo,
 "Quantum Annealing Implementation of Job-Shop Scheduling",
 `arXiv:1506.08479v2 <https://arxiv.org/abs/1506.08479v2>`_

--- a/job-shop-scheduling/README.rst
+++ b/job-shop-scheduling/README.rst
@@ -19,6 +19,9 @@ as possible?
 Here is a breakfast example with making pancakes and frying some eggs:
 ::
 
+  # Interpret as
+  # {"job_name": [("machine_name", duration_on_machine), ..], ..}
+
   {"pancakes": [("mixer", 5), ("stove", 2)],
    "eggs": [("stove", 3)]}
 
@@ -62,9 +65,9 @@ code.
 
 Input
 ~~~~~
-'jobs' dict describes the jobs we're interested in scheduling. Namely, the dict
-key is the name of the job and the dict value is the ordered list of tasks that
-the job must do.
+The jobs dictionary describes the jobs we're interested in scheduling. Namely,
+the dictionary key is the name of the job and the dictionary value is the
+ordered list of tasks that the job must do.
 
 It follows the format:
 ::

--- a/job-shop-scheduling/demo.py
+++ b/job-shop-scheduling/demo.py
@@ -47,7 +47,8 @@ solution = sampleset.first.sample
 #  2.
 #
 #  Hence, we are grabbing the nodes selected by our solver (i.e. nodes flagged
-#  with 1s) that will make a good schedule. (see 'selected_nodes')
+#  with 1s) that will make a good schedule.
+#  (see next line of code, 'selected_nodes')
 #
 # Note2: if a start_time_for_task == -1, it means that the solution is invalid
 

--- a/job-shop-scheduling/demo.py
+++ b/job-shop-scheduling/demo.py
@@ -20,7 +20,7 @@ from dwave.system.samplers import DWaveSampler
 from job_shop_scheduler import get_jss_bqm
 
 # Construct a BQM for the jobs
-jobs = {"cake": [("mixer", 2), ("oven", 1)],
+jobs = {"cupcakes": [("mixer", 2), ("oven", 1)],
         "smoothie": [("mixer", 1)],
         "lasagna": [("oven", 2)]}
 max_time = 4	  # Upperbound on how long the schedule can be

--- a/job-shop-scheduling/demo.py
+++ b/job-shop-scheduling/demo.py
@@ -19,10 +19,10 @@ from dwave.system.samplers import DWaveSampler
 
 from job_shop_scheduler import get_jss_bqm
 
-# Construct a BQM for jobs 'a', 'b' and 'c'
-jobs = {"a": [("mixer", 2), ("oven", 1)],
-        "b": [("mixer", 1)],
-        "c": [("oven", 2)]}
+# Construct a BQM for the jobs
+jobs = {"cake": [("mixer", 2), ("oven", 1)],
+        "smoothie": [("mixer", 1)],
+        "lasagna": [("oven", 2)]}
 max_time = 4	  # Upperbound on how long the schedule can be
 bqm = get_jss_bqm(jobs, max_time)
 
@@ -35,18 +35,18 @@ sampleset = sampler.sample(bqm, chain_strength=2, num_reads=1000)
 solution = sampleset.first.sample
 
 # Visualize solution
-# Note0: each node in our BQM is labelled as "<job>_<task_index>,<time>".
+# Note0: we are making the solution simpler to interpret by restructuring it
+#  into the following format:
+#   task_times = {"job": [start_time_for_task0, start_time_for_task1, ..],
+#                 "other_job": [start_time_for_task0, ..]
+#                 ..}
+#
+# Note1: each node in our BQM is labelled as "<job>_<task_index>,<time>".
 #  For example, the node "a_1,2" refers to job 'a', its 1st task (where we are
 #  using zero-indexing, so task '("oven", 1)'), starting at time 2.
 #
 #  Hence, we are grabbing the nodes selected by our solver (i.e. nodes flagged
 #  with 1s) that will make a good schedule. (see 'selected_nodes')
-#
-# Note1: we are making the solution simpler to interpret by restructuring it
-#  into the following format:
-#   task_times = {"job": [start_time_for_task0, start_time_for_task1, ..],
-#                 "other_job": [start_time_for_task0, ..]
-#                 ..}
 #
 # Note2: if a start_time_for_task == -1, it means that the solution is invalid
 
@@ -64,9 +64,9 @@ for node in selected_nodes:
 # Print problem and restructured solution
 print("Jobs and their machine-specific tasks:")
 for job, task_list in jobs.items():
-    print("{}: {}".format(job, task_list))
+    print("{0:9}: {1}".format(job, task_list))
 
 print("\nJobs and the start times of each task:")
 for job, times in task_times.items():
-    print("{}: {}".format(job, times))
+    print("{0:9}: {1}".format(job, times))
 

--- a/job-shop-scheduling/demo.py
+++ b/job-shop-scheduling/demo.py
@@ -42,8 +42,9 @@ solution = sampleset.first.sample
 #                 ..}
 #
 # Note1: each node in our BQM is labelled as "<job>_<task_index>,<time>".
-#  For example, the node "a_1,2" refers to job 'a', its 1st task (where we are
-#  using zero-indexing, so task '("oven", 1)'), starting at time 2.
+#  For example, the node "cupcakes_1,2" refers to job 'cupcakes', its 1st task
+#  (where we are using zero-indexing, so task '("oven", 1)'), starting at time
+#  2.
 #
 #  Hence, we are grabbing the nodes selected by our solver (i.e. nodes flagged
 #  with 1s) that will make a good schedule. (see 'selected_nodes')

--- a/job-shop-scheduling/demo.py
+++ b/job-shop-scheduling/demo.py
@@ -35,25 +35,25 @@ sampleset = sampler.sample(bqm, chain_strength=2, num_reads=1000)
 solution = sampleset.first.sample
 
 # Visualize solution
-# Note0: Each node in our BQM is labelled as "<job>_<task_index>,<time>".
+# Note0: each node in our BQM is labelled as "<job>_<task_index>,<time>".
 #  For example, the node "a_1,2" refers to job 'a', its 1st task (where we are
 #  using zero-indexing, so task '("oven", 1)'), starting at time 2.
 #
 #  Hence, we are grabbing the nodes selected by our solver (i.e. nodes flagged
 #  with 1s) that will make a good schedule. (see 'selected_nodes')
 #
-# Note1: We are making the solution simpler to interpret by restructuring it
+# Note1: we are making the solution simpler to interpret by restructuring it
 #  into the following format:
 #   task_times = {"job": [start_time_for_task0, start_time_for_task1, ..],
 #                 "other_job": [start_time_for_task0, ..]
 #                 ..}
 #
-# Note2: If a start_time_for_task == -1, it means that the solution is invalid
+# Note2: if a start_time_for_task == -1, it means that the solution is invalid
 
-# Grabbing selected nodes
+# Grab selected nodes
 selected_nodes = [k for k, v in solution.items() if v == 1]
 
-# Parsing node information
+# Parse node information
 task_times = {k: [-1]*len(v) for k, v in jobs.items()}
 for node in selected_nodes:
     job_name, task_time = node.rsplit("_", 1)

--- a/job-shop-scheduling/demo.py
+++ b/job-shop-scheduling/demo.py
@@ -1,0 +1,72 @@
+# Copyright 2019 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+from dwave.system.composites import EmbeddingComposite
+from dwave.system.samplers import DWaveSampler
+
+from job_shop_scheduler import get_jss_bqm
+
+# Construct a BQM for jobs 'a', 'b' and 'c'
+jobs = {"a": [("mixer", 2), ("oven", 1)],
+        "b": [("mixer", 1)],
+        "c": [("oven", 2)]}
+max_time = 4	  # Upperbound on how long the schedule can be
+bqm = get_jss_bqm(jobs, max_time)
+
+# Submit BQM
+# Note: may need to tweak the chain strength and the number of reads
+sampler = EmbeddingComposite(DWaveSampler(solver={'qpu':True}))
+sampleset = sampler.sample(bqm, chain_strength=2, num_reads=1000)
+
+# Grab solution
+solution = sampleset.first.sample
+
+# Visualize solution
+# Note0: Each node in our BQM is labelled as "<job>_<task_index>,<time>".
+#  For example, the node "a_1,2" refers to job 'a', its 1st task (where we are
+#  using zero-indexing, so task '("oven", 1)'), starting at time 2.
+#
+#  Hence, we are grabbing the nodes selected by our solver (i.e. nodes flagged
+#  with 1s) that will make a good schedule. (see 'selected_nodes')
+#
+# Note1: We are making the solution simpler to interpret by restructuring it
+#  into the following format:
+#   task_times = {"job": [start_time_for_task0, start_time_for_task1, ..],
+#                 "other_job": [start_time_for_task0, ..]
+#                 ..}
+#
+# Note2: If a start_time_for_task == -1, it means that the solution is invalid
+
+# Grabbing selected nodes
+selected_nodes = [k for k, v in solution.items() if v == 1]
+
+# Parsing node information
+task_times = {k: [-1]*len(v) for k, v in jobs.items()}
+for node in selected_nodes:
+    job_name, task_time = node.rsplit("_", 1)
+    task_index, start_time = map(int, task_time.split(","))
+
+    task_times[job_name][task_index] = start_time
+    
+# Print problem and restructured solution
+print("Jobs and their machine-specific tasks:")
+for job, task_list in jobs.items():
+    print("{}: {}".format(job, task_list))
+
+print("\nJobs and the start times of each task:")
+for job, times in task_times.items():
+    print("{}: {}".format(job, times))
+

--- a/job-shop-scheduling/demo.py
+++ b/job-shop-scheduling/demo.py
@@ -23,7 +23,7 @@ from job_shop_scheduler import get_jss_bqm
 jobs = {"cupcakes": [("mixer", 2), ("oven", 1)],
         "smoothie": [("mixer", 1)],
         "lasagna": [("oven", 2)]}
-max_time = 4	  # Upperbound on how long the schedule can be
+max_time = 4	  # Upperbound on how long the schedule can be; 4 is arbitrary
 bqm = get_jss_bqm(jobs, max_time)
 
 # Submit BQM

--- a/job-shop-scheduling/requirements.txt
+++ b/job-shop-scheduling/requirements.txt
@@ -1,1 +1,1 @@
-dwave-ocean-sdk==1.2.0
+dwave-ocean-sdk==1.4.0


### PR DESCRIPTION
* Add JSS readme
* Add a `demo.py` for users to run JSS out-of-the-box. (Previously, users would have to import `job_shop_scheduler.py` as a module before they could run a job shop scheduling problem)