### PR TITLE
Feature proposal for job-shop-scheduling

### DIFF
--- a/job-shop-scheduling/job_shop_scheduler.py
+++ b/job-shop-scheduling/job_shop_scheduler.py
@@ -67,9 +67,10 @@ def get_jss_bqm(job_dict, max_time=None, stitch_kwargs=None):
           - Job a's 1st task is ("oven", 1)
           - Hence, at time 0, Job a's 1st task is not run
     """
-    scheduler = JobShopScheduler(job_dict, max_time)
     if stitch_kwargs == None:
         stitch_kwargs = {}
+
+    scheduler = JobShopScheduler(job_dict, max_time)
     return scheduler.get_bqm(stitch_kwargs)
 
 
@@ -264,6 +265,9 @@ class JobShopScheduler:
         Args:
             stitch_kwargs: A dict. Kwargs to be passed to dwavebinarycsp.stitch.
         """
+        if stitch_kwargs == None:
+            stitch_kwargs = {}
+
         # Apply constraints to self.csp
         self._add_one_start_constraint()
         self._add_precedence_constraint()
@@ -271,8 +275,6 @@ class JobShopScheduler:
         self._remove_absurd_times()
 
         # Get BQM
-        if stitch_kwargs == None:
-            stitch_kwargs = {}
         bqm = dwavebinarycsp.stitch(self.csp, **stitch_kwargs)
 
         # Edit BQM to encourage the shortest schedule

--- a/job-shop-scheduling/job_shop_scheduler.py
+++ b/job-shop-scheduling/job_shop_scheduler.py
@@ -19,7 +19,7 @@ from bisect import bisect_right
 import dwavebinarycsp
 
 
-def get_jss_bqm(job_dict, max_time=None, stitch_kwargs={}):
+def get_jss_bqm(job_dict, max_time=None, stitch_kwargs=None):
     """Returns a BQM to the Job Shop Scheduling problem.
 
     Args:
@@ -68,6 +68,8 @@ def get_jss_bqm(job_dict, max_time=None, stitch_kwargs={}):
           - Hence, at time 0, Job a's 1st task is not run
     """
     scheduler = JobShopScheduler(job_dict, max_time)
+    if stitch_kwargs == None:
+        stitch_kwargs = {}
     return scheduler.get_bqm(stitch_kwargs)
 
 
@@ -245,7 +247,7 @@ class JobShopScheduler:
                 predecessor_time += job_task.duration
                 successor_time -= job_task.duration
 
-    def get_bqm(self, stitch_kwargs={}):
+    def get_bqm(self, stitch_kwargs=None):
         """Returns a BQM to the Job Shop Scheduling problem.
 
         Args:
@@ -258,6 +260,8 @@ class JobShopScheduler:
         self._remove_absurd_times()
 
         # Get BQM
+        if stitch_kwargs == None:
+            stitch_kwargs = {}
         bqm = dwavebinarycsp.stitch(self.csp, **stitch_kwargs)
 
         # Edit BQM to encourage the shortest schedule

--- a/job-shop-scheduling/job_shop_scheduler.py
+++ b/job-shop-scheduling/job_shop_scheduler.py
@@ -229,7 +229,7 @@ class JobShopScheduler:
         """
         jobs = set([task.job for task in self.tasks])
         for job in jobs:
-            job_tasks = sorted([task for task in self.tasks if task.job == job], key=lambda x: x.position)
+            job_tasks = [task for task in self.tasks if task.job == job]
             predecessor_time = 0
             successor_time = sum([job_task.duration for job_task in job_tasks])
             for job_task in job_tasks:

--- a/job-shop-scheduling/test_job_shop_scheduler.py
+++ b/job-shop-scheduling/test_job_shop_scheduler.py
@@ -392,10 +392,10 @@ class TestGetJssBqm(unittest.TestCase):
         jobs = {"sandwich": [("bread", 1), ("roast_beef", 1)],
                 "french_toast": [("egg", 1), ("bread", 1)]}
         max_time = 3
-        impossible_stitch_kwargs = {"max_graph_size": 0}
+        bad_stitch_kwargs = {"max_graph_size": 0}
 
         # ImpossibleBQM should be raised, as the max_graph size is too small
-        self.assertRaises(ImpossibleBQM, get_jss_bqm, jobs, max_time, impossible_stitch_kwargs)
+        self.assertRaises(ImpossibleBQM, get_jss_bqm, jobs, max_time, bad_stitch_kwargs)
 
 
 class TestGetBqm(unittest.TestCase):
@@ -405,10 +405,11 @@ class TestGetBqm(unittest.TestCase):
         jobs = {"sandwich": [("bread", 1), ("roast_beef", 1)],
                 "french_toast": [("egg", 1), ("bread", 1)]}
         max_time = 3
-        impossible_stitch_kwargs = {"max_graph_size": 0}
+        bad_stitch_kwargs = {"max_graph_size": 0}
 
         # ImpossibleBQM should be raised, as the max_graph size is too small
-        self.assertRaises(ImpossibleBQM, get_jss_bqm, jobs, max_time, impossible_stitch_kwargs)
+        scheduler = JobShopScheduler(jobs, max_time)
+        self.assertRaises(ImpossibleBQM, scheduler.get_bqm, bad_stitch_kwargs)
 
 
 if __name__ == "__main__":

--- a/job-shop-scheduling/test_job_shop_scheduler.py
+++ b/job-shop-scheduling/test_job_shop_scheduler.py
@@ -387,7 +387,7 @@ class TestGetJssBqm(unittest.TestCase):
         self.assertIsInstance(bqm, BinaryQuadraticModel)
 
     def test_stitch_kwargs(self):
-        """ Ensure stitch_kwargs is being passed through get_jss_bqm to dwavebinarycsp.stitch
+        """Ensure stitch_kwargs is being passed through get_jss_bqm to dwavebinarycsp.stitch
         """
         jobs = {"sandwich": [("bread", 1), ("roast_beef", 1)],
                 "french_toast": [("egg", 1), ("bread", 1)]}
@@ -400,7 +400,7 @@ class TestGetJssBqm(unittest.TestCase):
 
 class TestGetBqm(unittest.TestCase):
     def test_stitch_kwargs(self):
-        """ Ensure stitch_kwargs is being passed to dwavebinarycsp.stitch
+        """Ensure stitch_kwargs is being passed to dwavebinarycsp.stitch
         """
         jobs = {"sandwich": [("bread", 1), ("roast_beef", 1)],
                 "french_toast": [("egg", 1), ("bread", 1)]}

--- a/job-shop-scheduling/test_job_shop_scheduler.py
+++ b/job-shop-scheduling/test_job_shop_scheduler.py
@@ -19,6 +19,7 @@ import unittest
 from dimod import ExactSolver, BinaryQuadraticModel
 from job_shop_scheduler import JobShopScheduler, get_jss_bqm
 from tabu import TabuSampler
+from dwavebinarycsp.exceptions import ImpossibleBQM
 
 
 def fill_with_zeros(expected_solution_dict, job_dict, max_time):
@@ -384,6 +385,30 @@ class TestGetJssBqm(unittest.TestCase):
 
         bqm = get_jss_bqm(jobs, max_time)
         self.assertIsInstance(bqm, BinaryQuadraticModel)
+
+    def test_stitch_kwargs(self):
+        """ Ensure stitch_kwargs is being passed through get_jss_bqm to dwavebinarycsp.stitch
+        """
+        jobs = {"sandwich": [("bread", 1), ("roast_beef", 1)],
+                "french_toast": [("egg", 1), ("bread", 1)]}
+        max_time = 3
+        impossible_stitch_kwargs = {"max_graph_size": 0}
+
+        # ImpossibleBQM should be raised, as the max_graph size is too small
+        self.assertRaises(ImpossibleBQM, get_jss_bqm, jobs, max_time, impossible_stitch_kwargs)
+
+
+class TestGetBqm(unittest.TestCase):
+    def test_stitch_kwargs(self):
+        """ Ensure stitch_kwargs is being passed to dwavebinarycsp.stitch
+        """
+        jobs = {"sandwich": [("bread", 1), ("roast_beef", 1)],
+                "french_toast": [("egg", 1), ("bread", 1)]}
+        max_time = 3
+        impossible_stitch_kwargs = {"max_graph_size": 0}
+
+        # ImpossibleBQM should be raised, as the max_graph size is too small
+        self.assertRaises(ImpossibleBQM, get_jss_bqm, jobs, max_time, impossible_stitch_kwargs)
 
 
 if __name__ == "__main__":

--- a/job-shop-scheduling/test_job_shop_scheduler.py
+++ b/job-shop-scheduling/test_job_shop_scheduler.py
@@ -392,9 +392,14 @@ class TestGetJssBqm(unittest.TestCase):
         jobs = {"sandwich": [("bread", 1), ("roast_beef", 1)],
                 "french_toast": [("egg", 1), ("bread", 1)]}
         max_time = 3
-        bad_stitch_kwargs = {"max_graph_size": 0}
+
+        # Verify that reasonable stitch args result in a BQM
+        good_stitch_kwargs = {"max_graph_size": 6, "min_classical_gap": 1.5}
+        bqm = get_jss_bqm(jobs, max_time, good_stitch_kwargs)
+        self.assertIsInstance(bqm, BinaryQuadraticModel)
 
         # ImpossibleBQM should be raised, as the max_graph size is too small
+        bad_stitch_kwargs = {"max_graph_size": 0}
         self.assertRaises(ImpossibleBQM, get_jss_bqm, jobs, max_time, bad_stitch_kwargs)
 
 
@@ -405,9 +410,15 @@ class TestGetBqm(unittest.TestCase):
         jobs = {"sandwich": [("bread", 1), ("roast_beef", 1)],
                 "french_toast": [("egg", 1), ("bread", 1)]}
         max_time = 3
-        bad_stitch_kwargs = {"max_graph_size": 0}
+
+        # Verify that reasonable stitch args result in a BQM
+        good_stitch_kwargs = {"max_graph_size": 6, "min_classical_gap": 1.5}
+        scheduler = JobShopScheduler(jobs, max_time)
+        bqm = scheduler.get_bqm(good_stitch_kwargs)
+        self.assertIsInstance(bqm, BinaryQuadraticModel)
 
         # ImpossibleBQM should be raised, as the max_graph size is too small
+        bad_stitch_kwargs = {"max_graph_size": 0}
         scheduler = JobShopScheduler(jobs, max_time)
         self.assertRaises(ImpossibleBQM, scheduler.get_bqm, bad_stitch_kwargs)
 


### PR DESCRIPTION
I have two features that I think would improve the usability and performance of the job-shop-scheduling demo.

First, for jobs larger than those in the demo/testing files get_bqm may fail on the  dwavebinarycsp.stitch if the default max_graph_size is too small. My first commit allows parameters to be passed through to dwavebinarycsp.stitch.

Second, the current variable pruning does not take advantage of knowledge of all tasks (I believe the TODO refers to this). Variables of a task are pruned only on their position within a job, and their duration. Pruning can be improved considering the duration of predecessor and successor tasks. The changes for this are in the second commit.