### PR TITLE
Feature/moderate readme fixes to match template

### DIFF
--- a/circuit-fault-diagnosis/README.rst
+++ b/circuit-fault-diagnosis/README.rst
@@ -1,7 +1,8 @@
 Demo of Circuit Fault Diagnosis
 ===============================
-Fault diagnosis is the combinational problem of quickly localizing failures as soon as they are detected in systems.
-Circuit fault diagnosis is the problem of identifying a minimum-sized set of components that, if faulty, explains an
+Fault diagnosis is the combinational problem of quickly localizing failures as
+soon as they are detected in systems. Circuit fault diagnosis is the problem of
+identifying a minimum-sized set of components that, if faulty, explains an
 observation of incorrect outputs given a set of inputs.
 
 Usage
@@ -12,9 +13,11 @@ Run ``demo.py`` and then follow the on-screen instructions.
 
 Code Overview
 -------------
-This code demonstrates the use of the D-Wave system to solve such a problem in the case of a three-bit multiplier
-circuit. The user is prompted to enter three integers: A and B, which are the inputs the circuit is expected to
-multiply, and the circuit's output, P, which represents either a valid or incorrect product of the inputs.
+This code demonstrates the use of the D-Wave system to solve such a problem in
+the case of a three-bit multiplier circuit. The user is prompted to enter three
+integers: A and B, which are the inputs the circuit is expected to multiply,
+and the circuit's output, P, which represents either a valid or incorrect
+product of the inputs.
 
 .. code-block::
 
@@ -22,8 +25,9 @@ multiply, and the circuit's output, P, which represents either a valid or incorr
   Input multiplicand   ( 0 <= B <=  7):
   Input product        ( 0 <= P <= 63):
 
-The algorithm returns the minimum fault diagnosis (the smallest number of faulty components it found to cause the given
-inputs and product) and the number of distinct fault states with this many faults it observed.
+The algorithm returns the minimum fault diagnosis (the smallest number of
+faulty components it found to cause the given inputs and product) and the
+number of distinct fault states with this many faults it observed.
 
 Code Specifics
 --------------
@@ -31,17 +35,19 @@ Code Specifics
 Advanced Options
 ~~~~~~~~~~~~~~~~
 
-The :code:`--verbose` option displays the valid/fault status of each component for each minimum fault diagnosis.
+The ``--verbose`` option displays the valid/fault status of each component for
+each minimum fault diagnosis.
 
 .. code-block:: bash
 
   python demo.py --verbose
 
 Interesting Use Cases
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
-A single faulty component leads to five incorrect bits in the product's six bits (due to the commutative property of
-multiplication, these are two isomorphic sets) in these four cases:
+A single faulty component leads to five incorrect bits in the product's six
+bits (due to the commutative property of multiplication, these are two
+isomorphic sets) in these four cases:
 
 .. code-block::
 
@@ -50,8 +56,9 @@ multiplication, these are two isomorphic sets) in these four cases:
   A = 7; B = 4; P = 34
   A = 4; B = 7; P = 34
 
-Two faulty components lead to all the product's six bits being incorrect (this is due to the least significant bit being
-determined solely by one AND gate) in these four cases:
+Two faulty components lead to all the product's six bits being incorrect (this
+is due to the least significant bit being determined solely by one AND gate) in
+these four cases:
 
 .. code-block::
 
@@ -60,22 +67,29 @@ determined solely by one AND gate) in these four cases:
   A = 7; B = 4; P = 35
   A = 4; B = 7; P = 35
 
-Four faulty components, which is the maximum number of faulty components for a minimum fault diagnosis for this circuit,
-lead to five incorrect bits in the product's six bits in this case (one of many such cases):
+Four faulty components, which is the maximum number of faulty components for a
+minimum fault diagnosis for this circuit, lead to five incorrect bits in the
+product's six bits in this case (one of many such cases):
 
 .. code-block::
 
   A = 7; B = 6; P = 1
 
-In general, the number of incorrect bits in the product is greater than or equal to the number of faulty components.
+In general, the number of incorrect bits in the product is greater than or
+equal to the number of faulty components.
 
 References
 ----------
 
-Z. Bian, F. Chudak, R. B. Israel, B. Lackey, W. G. Macready, and A. Roy, “Mapping constrained optimization problems to quantum annealing with application to fault diagnosis,” Frontiers in ICT, vol. 3, p. 14, 2016.
+Z. Bian, F. Chudak, R. B. Israel, B. Lackey, W. G. Macready, and A. Roy,
+“Mapping constrained optimization problems to quantum annealing with
+application to fault diagnosis,” Frontiers in ICT, vol. 3, p. 14, 2016.
 https://www.frontiersin.org/articles/10.3389/fict.2016.00014/full
 
-A. Perdomo-Ortiz, J. Fluegemann, S. Narasimhan, R. Biswas, and V. N. Smelyanskiy, “A quantum annealing approach for fault detection and diagnosis of graph-based systems,” European Physical Journal Special Topics, vol. 224, Feb. 2015.
+A. Perdomo-Ortiz, J. Fluegemann, S. Narasimhan, R. Biswas, and V. N.
+Smelyanskiy, “A quantum annealing approach for fault detection and diagnosis of
+graph-based systems,” European Physical Journal Special Topics, vol. 224, Feb.
+2015.
 https://arxiv.org/abs/1406.7601v2
 
 License

--- a/circuit-fault-diagnosis/README.rst
+++ b/circuit-fault-diagnosis/README.rst
@@ -1,10 +1,17 @@
 Demo of Circuit Fault Diagnosis
 ===============================
-
 Fault diagnosis is the combinational problem of quickly localizing failures as soon as they are detected in systems.
 Circuit fault diagnosis is the problem of identifying a minimum-sized set of components that, if faulty, explains an
 observation of incorrect outputs given a set of inputs.
 
+Usage
+-----
+Run ``demo.py`` and then follow the on-screen instructions.
+::
+  python demo.py
+
+Code Overview
+-------------
 This code demonstrates the use of the D-Wave system to solve such a problem in the case of a three-bit multiplier
 circuit. The user is prompted to enter three integers: A and B, which are the inputs the circuit is expected to
 multiply, and the circuit's output, P, which represents either a valid or incorrect product of the inputs.
@@ -17,6 +24,9 @@ multiply, and the circuit's output, P, which represents either a valid or incorr
 
 The algorithm returns the minimum fault diagnosis (the smallest number of faulty components it found to cause the given
 inputs and product) and the number of distinct fault states with this many faults it observed.
+
+Code Specifics
+--------------
 
 Advanced Options
 ~~~~~~~~~~~~~~~~
@@ -59,13 +69,8 @@ lead to five incorrect bits in the product's six bits in this case (one of many 
 
 In general, the number of incorrect bits in the product is greater than or equal to the number of faulty components.
 
-License
--------
-
-Released under the Apache License 2.0. See LICENSE file.
-
-Further Reading
----------------
+References
+----------
 
 * Z. Bian, F. Chudak, R. B. Israel, B. Lackey, W. G. Macready, and A. Roy, “Mapping constrained optimization problems
   to quantum annealing with application to fault diagnosis,” Frontiers in ICT, vol. 3, p. 14, 2016.
@@ -74,9 +79,7 @@ Further Reading
   fault detection and diagnosis of graph-based systems,” European Physical Journal Special Topics, vol. 224, Feb. 2015.
   https://arxiv.org/abs/1406.7601v2
 
-.. _`penaltymodel_maxgap`: https://github.com/dwavesystems/penaltymodel_maxgap
-.. _pysmt: https://github.com/pysmt/pysmt
-.. _`qbsolv's`: https://github.com/dwavesystems/qbsolv
-.. _`dwave-cloud-client`: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
-.. _z3: https://github.com/Z3Prover/z3
-.. _`pysmt installation instructions`: https://github.com/pysmt/pysmt#installation
+License
+-------
+Released under the Apache License 2.0. See `LICENSE <../LICENSE>`_ file.
+

--- a/circuit-fault-diagnosis/README.rst
+++ b/circuit-fault-diagnosis/README.rst
@@ -72,12 +72,11 @@ In general, the number of incorrect bits in the product is greater than or equal
 References
 ----------
 
-* Z. Bian, F. Chudak, R. B. Israel, B. Lackey, W. G. Macready, and A. Roy, “Mapping constrained optimization problems
-  to quantum annealing with application to fault diagnosis,” Frontiers in ICT, vol. 3, p. 14, 2016.
-  https://www.frontiersin.org/articles/10.3389/fict.2016.00014/full
-* A. Perdomo-Ortiz, J. Fluegemann, S. Narasimhan, R. Biswas, and V. N. Smelyanskiy, “A quantum annealing approach for
-  fault detection and diagnosis of graph-based systems,” European Physical Journal Special Topics, vol. 224, Feb. 2015.
-  https://arxiv.org/abs/1406.7601v2
+Z. Bian, F. Chudak, R. B. Israel, B. Lackey, W. G. Macready, and A. Roy, “Mapping constrained optimization problems to quantum annealing with application to fault diagnosis,” Frontiers in ICT, vol. 3, p. 14, 2016.
+https://www.frontiersin.org/articles/10.3389/fict.2016.00014/full
+
+A. Perdomo-Ortiz, J. Fluegemann, S. Narasimhan, R. Biswas, and V. N. Smelyanskiy, “A quantum annealing approach for fault detection and diagnosis of graph-based systems,” European Physical Journal Special Topics, vol. 224, Feb. 2015.
+https://arxiv.org/abs/1406.7601v2
 
 License
 -------

--- a/factoring/README.rst
+++ b/factoring/README.rst
@@ -1,6 +1,8 @@
 Demo of Factoring
 =================
-This code demonstrates the use of the D-Wave system to solve such a factoring problem three-bit multiplier circuit.
+This code demonstrates the use of the D-Wave system to solve a factoring
+problem. This is done by turning said problem into a three-bit multiplier
+circuit.
 
 Usage
 -----
@@ -23,11 +25,22 @@ multiplies to calculate the product, P.
 
 Code Overview
 -------------
-Integer factoring is the decomposition of an integer into factors that, when multiplied together, give the original number. For example, the factors of 15 are 3 and 5.
+Integer factoring is the decomposition of an integer into factors that, when
+multiplied together, give the original number. For example, the factors of 15
+are 3 and 5.
 
-D-Wave quantum computers allow us to factor numbers in an entirely new way, by turning a multiplication circuit into a constraint satisfaction problem that allows the quantum computer to compute inputs from a predefined output. Essentially, this means running the multiplication circuit in reverse!
+D-Wave quantum computers allow us to factor numbers in an entirely new way, by
+turning a multiplication circuit into a constraint satisfaction problem that
+allows the quantum computer to compute inputs from a predefined output.
+Essentially, this means running the multiplication circuit in reverse!
 
-A Boolean logic circuit is usually viewed as computing outputs from inputs based on the logic of the gates. However, the problem can also be thought of as seeking an assignment of values to the inputs and outputs consistent with the logic of all the gates in the circuit.  This perspective of constraint satisfaction has no directionality. That is, input values do not need to flow through a series of gates to yield a result, as they do in a multiplication circuit.
+A Boolean logic circuit is usually viewed as computing outputs from inputs
+based on the logic of the gates. However, the problem can also be thought of as
+seeking an assignment of values to the inputs and outputs consistent with the
+logic of all the gates in the circuit.  This perspective of constraint
+satisfaction has no directionality. That is, input values do not need to flow
+through a series of gates to yield a result, as they do in a multiplication
+circuit.
 
 
 Code Specifics

--- a/factoring/README.rst
+++ b/factoring/README.rst
@@ -1,40 +1,39 @@
 Demo of Factoring
 =================
+This code demonstrates the use of the D-Wave system to solve such a factoring problem three-bit multiplier circuit.
 
-Integer factoring is the decomposition of an integer into factors that, when multiplied together, give the original
-number. For example, the factors of 15 are 3 and 5.
-
-D-Wave quantum computers allow us to factor numbers in an entirely new way, by turning a multiplication circuit into a
-constraint satisfaction problem that allows the quantum computer to compute inputs from a predefined output.
-Essentially, this means running the multiplication circuit in reverse!
-
-A Boolean logic circuit is usually viewed as computing outputs from inputs based on the logic of the gates.  However,
-the problem can also be thought of as seeking an assignment of values to the inputs and outputs consistent with the
-logic of all the gates in the circuit.  This perspective of constraint satisfaction has no directionality. That is,
-input values do not need to flow through a series of gates to yield a result, as they do in a multiplication circuit.
-
-This code demonstrates the use of the D-Wave system to solve such a problem in the case of a three-bit multiplier
-circuit.
-
-Running the Demo
-----------------
-
-A minimal working example using the main interface function can be seen by running:
+Usage
+-----
+A minimal working example using the main interface function can be seen by
+running:
 
 .. code-block:: bash
 
   python demo.py
 
-The user is prompted to enter a six-bit integer: P, which represents a product to be factored.
+The user is prompted to enter a six-bit integer: P, which represents a product
+to be factored.
 
 .. code-block::
 
   Input product        ( 0 <= P <= 63):
 
-The algorithm returns possible A and B values, which are the inputs the circuit multiplies to calculate the product, P.
+The algorithm returns possible A and B values, which are the inputs the circuit
+multiplies to calculate the product, P.
 
-By default, the main interface function uses a saved embedding. This can be overriden and the code to calculate a new
-embedding can be called by using:
+Code Overview
+-------------
+Integer factoring is the decomposition of an integer into factors that, when multiplied together, give the original number. For example, the factors of 15 are 3 and 5.
+
+D-Wave quantum computers allow us to factor numbers in an entirely new way, by turning a multiplication circuit into a constraint satisfaction problem that allows the quantum computer to compute inputs from a predefined output. Essentially, this means running the multiplication circuit in reverse!
+
+A Boolean logic circuit is usually viewed as computing outputs from inputs based on the logic of the gates. However, the problem can also be thought of as seeking an assignment of values to the inputs and outputs consistent with the logic of all the gates in the circuit.  This perspective of constraint satisfaction has no directionality. That is, input values do not need to flow through a series of gates to yield a result, as they do in a multiplication circuit.
+
+
+Code Specifics
+--------------
+By default, the main interface function uses a saved embedding. This can be
+overriden and the code to calculate a new embedding can be called by using:
 
 .. code-block:: python
 

--- a/factoring/README.rst
+++ b/factoring/README.rst
@@ -1,6 +1,3 @@
-.. image:: https://circleci.com/gh/dwavesystems/factoring-demo.svg?style=svg
-    :target: https://circleci.com/gh/dwavesystems/factoring-demo
-
 Demo of Factoring
 =================
 
@@ -18,23 +15,6 @@ input values do not need to flow through a series of gates to yield a result, as
 
 This code demonstrates the use of the D-Wave system to solve such a problem in the case of a three-bit multiplier
 circuit.
-
-Setting Up the Demo
--------------------
-
-Copy (clone) this factoring-demo repository to your local machine
-
-To set up the required dependencies, in the root directory of a copy (clone) of this repository, run the following:
-
-.. code-block:: bash
-
-  pip install .
-
-Configuring the Demo
---------------------
-
-Access to a D-Wave system must be configured, as described in the `dwave-cloud-client`_ documentation. A default solver
-is required.
 
 Running the Demo
 ----------------
@@ -65,4 +45,3 @@ License
 
 Released under the Apache License 2.0. See LICENSE file.
 
-.. _`dwave-cloud-client`: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config

--- a/factoring/README.rst
+++ b/factoring/README.rst
@@ -42,6 +42,5 @@ embedding can be called by using:
 
 License
 -------
-
-Released under the Apache License 2.0. See LICENSE file.
+Released under the Apache License 2.0. See `LICENSE <../LICENSE>`_ file.
 

--- a/qboost/README.rst
+++ b/qboost/README.rst
@@ -1,15 +1,26 @@
 Demo of Qboost
 ==============
-The D-Wave quantum computer has been widely studied as a discrete optimization engine that accepts
-any problem formulated as quadratic unconstrained  binary  optimization  (QUBO). In 2008, Google and
-D-Wave published a paper, `Training a Binary Classifier with the Quantum Adiabatic Algorithm <https://arxiv.org/pdf/0811.0416.pdf>`_,
-which describes how the Qboost ensemble method makes binary classification amenable to quantum
-computing: the problem is formulated as a thresholded linear superposition of a set of weak classifiers
-and the D-Wave quantum computer is  used to optimize the weights in a learning process that
-strives to minimize the training error and number of weak classifiers
+The D-Wave quantum computer has been widely studied as a discrete optimization
+engine that accepts any problem formulated as quadratic unconstrained binary
+optimization (QUBO). In 2008, Google and D-Wave published a paper,
+`Training a Binary Classifier with the Quantum Adiabatic Algorithm
+<https://arxiv.org/pdf/0811.0416.pdf>`_, which describes how the Qboost
+ensemble method makes binary classification amenable to quantum computing: 
+the problem is formulated as a thresholded linear superposition of a set of
+weak classifiers and the D-Wave quantum computer is  used to optimize the
+weights in a learning process that strives to minimize the training error
+and number of weak classifiers
 
-This code demonstrates the use of the D-Wave system to solve a binary classification problem using the
-Qboost algorithm.
+This code demonstrates the use of the D-Wave system to solve a binary
+classification problem using the Qboost algorithm.
+
+Usage
+-----
+A minimal working example using the main interface function can be seen by running:
+
+.. code-block:: bash
+
+  python demo.py  --wisc --mnist
 
 Disclaimer
 ----------
@@ -19,16 +30,12 @@ designed for performance.
 For state-of-the-art machine learning, please contact `Quadrant <https://quadrant.ai/>`_, the
 machine learning business unit of D-Wave Systems.
 
-Running the Demo
-----------------
-A minimal working example using the main interface function can be seen by running:
-
-.. code-block:: bash
-
-  python demo.py  --wisc --mnist
+References
+----------
+H. Neven, V. S. Denchev, G. Rose, and W. G. Macready, "Training a Binary
+Classifier with the Quantum Adiabatic Algorithm", `arXiv:0811.0416v1 <https://arxiv.org/pdf/0811.0416.pdf>`
 
 License
 -------
 Released under the Apache License 2.0. See LICENSE file.
 
-.. _`Training a Binary Classifier with the Quantum Adiabatic Algorithm`: https://arxiv.org/pdf/0811.0416.pdf

--- a/qboost/README.rst
+++ b/qboost/README.rst
@@ -1,10 +1,9 @@
 Demo of Qboost
 ==============
-
 The D-Wave quantum computer has been widely studied as a discrete optimization engine that accepts
 any problem formulated as quadratic unconstrained  binary  optimization  (QUBO). In 2008, Google and
-D-Wave published a paper, `Training a Binary Classifier with the Quantum Adiabatic Algorithm`_\ ,
-which describes how the `Qboost` ensemble method makes binary classification amenable to quantum
+D-Wave published a paper, `Training a Binary Classifier with the Quantum Adiabatic Algorithm <https://arxiv.org/pdf/0811.0416.pdf>`_,
+which describes how the Qboost ensemble method makes binary classification amenable to quantum
 computing: the problem is formulated as a thresholded linear superposition of a set of weak classifiers
 and the D-Wave quantum computer is  used to optimize the weights in a learning process that
 strives to minimize the training error and number of weak classifiers
@@ -14,43 +13,14 @@ Qboost algorithm.
 
 Disclaimer
 ----------
-
 This demo and its code are intended for demonstrative purposes only and are not
 designed for performance.
 
-For state-of-the-art machine learning, please contact Quadrant, the
+For state-of-the-art machine learning, please contact `Quadrant <https://quadrant.ai/>`_, the
 machine learning business unit of D-Wave Systems.
-
-Setting Up the Demo
-----------------------
-
-It's recommended that you work in a `virtual environment`_ on your local machine; depending on
-your machine, you may need to first install virtualenv and then create a virtual environment,
-for example:
-
-.. code-block:: bash
-
-  virtualenv env
-  cd env
-  source ./bin/activate
-
-Copy (clone) this Qboost repository to your local machine's newly created virtual environment.
-
-To set up the required dependencies, in the root directory of a copy (clone) of this repository, run the following:
-
-.. code-block:: bash
-
-  pip install -r requirements.txt
-
-Configuring the Demo
---------------------
-
-Access to a D-Wave system must be configured, as described in the `dwave-cloud-client`_ documentation.
-A default solver is required.
 
 Running the Demo
 ----------------
-
 A minimal working example using the main interface function can be seen by running:
 
 .. code-block:: bash
@@ -59,9 +29,6 @@ A minimal working example using the main interface function can be seen by runni
 
 License
 -------
-
 Released under the Apache License 2.0. See LICENSE file.
 
-.. _`dwave-cloud-client`: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
 .. _`Training a Binary Classifier with the Quantum Adiabatic Algorithm`: https://arxiv.org/pdf/0811.0416.pdf
-.. _`virtual environment`: https://packaging.python.org/guides/installing-using-pip-and-virtualenv

--- a/qboost/README.rst
+++ b/qboost/README.rst
@@ -33,9 +33,9 @@ machine learning business unit of D-Wave Systems.
 References
 ----------
 H. Neven, V. S. Denchev, G. Rose, and W. G. Macready, "Training a Binary
-Classifier with the Quantum Adiabatic Algorithm", `arXiv:0811.0416v1 <https://arxiv.org/pdf/0811.0416.pdf>`
+Classifier with the Quantum Adiabatic Algorithm", `arXiv:0811.0416v1 <https://arxiv.org/pdf/0811.0416.pdf>`_
 
 License
 -------
-Released under the Apache License 2.0. See LICENSE file.
+Released under the Apache License 2.0. See `LICENSE <../LICENSE>`_ file.
 

--- a/qboost/README.rst
+++ b/qboost/README.rst
@@ -14,14 +14,6 @@ and number of weak classifiers
 This code demonstrates the use of the D-Wave system to solve a binary
 classification problem using the Qboost algorithm.
 
-Usage
------
-A minimal working example using the main interface function can be seen by running:
-
-.. code-block:: bash
-
-  python demo.py  --wisc --mnist
-
 Disclaimer
 ----------
 This demo and its code are intended for demonstrative purposes only and are not
@@ -29,6 +21,14 @@ designed for performance.
 
 For state-of-the-art machine learning, please contact `Quadrant <https://quadrant.ai/>`_, the
 machine learning business unit of D-Wave Systems.
+
+Usage
+-----
+A minimal working example using the main interface function can be seen by running:
+
+.. code-block:: bash
+
+  python demo.py  --wisc --mnist
 
 References
 ----------

--- a/structural-imbalance/README.rst
+++ b/structural-imbalance/README.rst
@@ -1,25 +1,7 @@
 Demo of Structural Imbalance in Signed Social Networks
 ======================================================
 
-*Social networks* map relationships between people or organizations onto graphs, with
-the people/organizations as nodes and relationships as edges; for example,
-Facebook friends form a social network with friends represented as
-nodes with connecting edges. *Signed social networks* map both friendly and
-hostile relationships by setting the values of the edges between nodes with either plus ("+")
-or minus ("-") signs. Such networks are said to be *structurally balanced* when they
-can be clearly divided into two, with friendly relations (represented by positive-valued
-edges) in each faction, and hostile relations (negative-valued edges) between these factions.
-
-The measure of *structural imbalance* or *frustration* for a signed social network
-is the minimum number of edges that violate this rule.
-
-.. figure:: _static/Social.png
-  :name: social
-  :alt: Three-person social network
-
-Social theory suggests that
-increased frustration predicts social instability. In the context of militant organizations,
-this can result in increased violence.
+Social theory suggests that increased frustration predicts social instability. In the context of militant organizations, this can result in increased violence.
 
 This demo calculates and shows structural imbalance for social networks of militant
 organization based on data from the Stanford Militants Mapping Project:
@@ -27,8 +9,8 @@ organization based on data from the Stanford Militants Mapping Project:
 Mapping Militant Organizations, Stanford University, last modified February 28, 2016,
 http://web.stanford.edu/group/mappingmilitants/cgi-bin/.
 
-Running the Demo
-----------------
+Usage
+-----
 To run the demo, execute one of the following two commands:
 
 A. Local CPU Execution
@@ -45,6 +27,26 @@ B. D-Wave System Execution
 
    python demo.py qpu
 
+Code Overview
+-------------
+*Social networks* map relationships between people or organizations onto graphs, with
+the people/organizations as nodes and relationships as edges; for example,
+Facebook friends form a social network with friends represented as
+nodes with connecting edges. *Signed social networks* map both friendly and
+hostile relationships by setting the values of the edges between nodes with either plus ("+")
+or minus ("-") signs. Such networks are said to be *structurally balanced* when they
+can be clearly divided into two, with friendly relations (represented by positive-valued
+edges) in each faction, and hostile relations (negative-valued edges) between these factions.
+
+The measure of *structural imbalance* or *frustration* for a signed social network
+is the minimum number of edges that violate this rule.
+
+.. figure:: _static/Social.png
+  :name: social
+  :alt: Three-person social network
+
+Code Specifics
+--------------
 The demo fetches data from the Stanford Militants Mapping Project, calculates the networks,
 and saves PNG-formatted graphic files and CSV-formatted files in the root directory of your
 copy of the demo repository and in a Results subdirectory.

--- a/structural-imbalance/README.rst
+++ b/structural-imbalance/README.rst
@@ -1,13 +1,26 @@
 Demo of Structural Imbalance in Signed Social Networks
 ======================================================
+*Social networks* map relationships between people or organizations onto graphs, with
+the people/organizations as nodes and relationships as edges; for example,
+Facebook friends form a social network with friends represented as
+nodes with connecting edges. *Signed social networks* map both friendly and
+hostile relationships by setting the values of the edges between nodes with either plus ("+")
+or minus ("-") signs. Such networks are said to be *structurally balanced* when they
+can be clearly divided into two, with friendly relations (represented by positive-valued
+edges) in each faction, and hostile relations (negative-valued edges) between these factions.
+
+The measure of *structural imbalance* or *frustration* for a signed social network
+is the minimum number of edges that violate this rule.
+
+.. figure:: _static/Social.png
+  :name: social
+  :alt: Three-person social network
 
 Social theory suggests that increased frustration predicts social instability. In the context of militant organizations, this can result in increased violence.
 
 This demo calculates and shows structural imbalance for social networks of militant
-organization based on data from the Stanford Militants Mapping Project:
+organization based on data from the `Stanford Militants Mapping Project <http://web.stanford.edu/group/mappingmilitants/cgi-bin/>`_.
 
-Mapping Militant Organizations, Stanford University, last modified February 28, 2016,
-http://web.stanford.edu/group/mappingmilitants/cgi-bin/.
 
 Usage
 -----
@@ -27,24 +40,6 @@ B. D-Wave System Execution
 
    python demo.py qpu
 
-Code Overview
--------------
-*Social networks* map relationships between people or organizations onto graphs, with
-the people/organizations as nodes and relationships as edges; for example,
-Facebook friends form a social network with friends represented as
-nodes with connecting edges. *Signed social networks* map both friendly and
-hostile relationships by setting the values of the edges between nodes with either plus ("+")
-or minus ("-") signs. Such networks are said to be *structurally balanced* when they
-can be clearly divided into two, with friendly relations (represented by positive-valued
-edges) in each faction, and hostile relations (negative-valued edges) between these factions.
-
-The measure of *structural imbalance* or *frustration* for a signed social network
-is the minimum number of edges that violate this rule.
-
-.. figure:: _static/Social.png
-  :name: social
-  :alt: Three-person social network
-
 Code Specifics
 --------------
 The demo fetches data from the Stanford Militants Mapping Project, calculates the networks,
@@ -53,6 +48,11 @@ copy of the demo repository and in a Results subdirectory.
 
 Note that this CLI command runs the entire demo and can take a few minutes to complete. You can
 easily modify the code to run just parts of the demo from within a Python interpreter.
+
+References
+----------
+Mapping Militant Organizations, Stanford University, last modified February 28, 2016,
+http://web.stanford.edu/group/mappingmilitants/cgi-bin/.
 
 License
 -------

--- a/structural-imbalance/README.rst
+++ b/structural-imbalance/README.rst
@@ -1,6 +1,3 @@
-.. image:: https://circleci.com/gh/dwavesystems/structural-imbalance-demo.svg?style=svg
-    :target: https://circleci.com/gh/dwavesystems/structural-imbalance-demo
-
 Demo of Structural Imbalance in Signed Social Networks
 ======================================================
 


### PR DESCRIPTION
- Just moving Demo Readme sections around to match the Demos Template
- Minor link and reference fixes
- demos affected: Circuit fault diagnosis, Factoring, Qboost, Structural imbalance