### PR TITLE
Fix/temporarily ignore long qboost tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ jobs:
                   . "$env/bin/activate"
 
                   cd "$demo"
+                  echo "$demo"
                   coverage run -m unittest discover
                 )
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       # Note: SUM_REQ_FILE is hardcoded for save_cache and restore_cache. See dicussion on
       # https://discuss.circleci.com/t/cannot-use-circle-yml-environment-variables-in-cache-keys/10994/20
       SUM_REQ_FILE: temp_requirements_summary.txt
-      IGNORED_DIRS: envs|tests|circuit-fault-diagnosis|factoring|template
+      IGNORED_DIRS: envs|tests|circuit-fault-diagnosis|factoring|template|qboost
 
     steps:
       - checkout
@@ -100,7 +100,7 @@ jobs:
       PYTHON: 3.7.0
       HOMEBREW_NO_AUTO_UPDATE: 1
       SUM_REQ_FILE: temp_requirements_summary.txt  # Note: hardcoded for save_cache and restore_cache
-      IGNORED_DIRS: envs|tests|circuit-fault-diagnosis|factoring|template
+      IGNORED_DIRS: envs|tests|circuit-fault-diagnosis|factoring|template|qboost
 
     working_directory: ~/repo
 
@@ -144,7 +144,7 @@ jobs:
       PYTHON: 3.6.5
       HOMEBREW_NO_AUTO_UPDATE: 1
       SUM_REQ_FILE: temp_requirements_summary.txt
-      IGNORED_DIRS: envs|tests|circuit-fault-diagnosis|factoring|template
+      IGNORED_DIRS: envs|tests|circuit-fault-diagnosis|factoring|template|qboost
 
   test-osx-3.5:
     <<: *osx-tests-template
@@ -152,7 +152,7 @@ jobs:
       PYTHON: 3.5.5
       HOMEBREW_NO_AUTO_UPDATE: 1
       SUM_REQ_FILE: temp_requirements_summary.txt
-      IGNORED_DIRS: envs|tests|circuit-fault-diagnosis|factoring|template
+      IGNORED_DIRS: envs|tests|circuit-fault-diagnosis|factoring|template|qboost
 
   test-osx-2.7:
     <<: *osx-tests-template
@@ -160,7 +160,7 @@ jobs:
       PYTHON: 2.7.15
       HOMEBREW_NO_AUTO_UPDATE: 1
       SUM_REQ_FILE: temp_requirements_summary.txt
-      IGNORED_DIRS: envs|tests|circuit-fault-diagnosis|factoring|template
+      IGNORED_DIRS: envs|tests|circuit-fault-diagnosis|factoring|template|qboost
 
 
   deploy:


### PR DESCRIPTION
* Qboost tests are taking over 3 minutes to run
* Eventually, Qboost will not have a jupyter notebook in Demos, so its `test_notebook.py` is not necessary
* For simplicity, I am ignoring `test_demo.py` (a little over a minute) as its also quite heavy
* Made an issue #90 to remind myself to add these tests back to CircleCI when things are in better shape