### PR TITLE
Feature/88 out of the box code for maze

### DIFF
--- a/maze/README.rst
+++ b/maze/README.rst
@@ -19,24 +19,24 @@ There are several constraints involved with a maze:
 - Path cannot pass maze borders
 - Path cannot pass through the internal walls of the maze
 
-Each of these constraints are implemented by the :code:`maze` functions:
-:code:`_apply_valid_move_constraint()`, :code:`_set_start_and_end()`, :code:`_set_borders()`, and
-:code:`_set_inner_walls()`, respectively. These functions are called when the user calls
-:code:`get_maze_bqm(..)` in the Example section below.
+Each of these constraints are implemented by the ``maze`` functions:
+``_apply_valid_move_constraint()``, ``_set_start_and_end()``, ``_set_borders()``, and
+``_set_inner_walls()``, respectively. These functions are called when the user calls
+``get_maze_bqm(..)`` in the Example section below.
 
 Code Specifics
 --------------
 The maze is a rectangular grid. The path segments (aka edges) that can be formed in this grid are
-described with respect to a grid point. For example, the edge labelled :code:`'1,0w'`:
+described with respect to a grid point. For example, the edge labelled ``'1,0w'``:
 
-- :code:`1,0` refers to grid point on row 1, column 0
-- :code:`w` refers to "west"
+- ``1,0`` refers to grid point on row 1, column 0
+- ``w`` refers to "west"
 
-Hence, if you imagine a compass that is centered at position :code:`1,0`, the edge :code:`'1,0w'`
+Hence, if you imagine a compass that is centered at position ``1,0``, the edge ``'1,0w'``
 is the path segment that sits along the western direction of this compass.
 
-Note that the code only accepts edge inputs in the north direction (:code:`'<row>,<col>n'`) and the
-west direction (:code:`'<row>,<col>w'`). Edges in south or east directions can be restated as edges
+Note that the code only accepts edge inputs in the north direction (``'<row>,<col>n'``) and the
+west direction (``'<row>,<col>w'``). Edges in south or east directions can be restated as edges
 in north and west directions:
 
 .. code-block:: none
@@ -76,7 +76,7 @@ Printed results:
 
 - The 1s and 0s beneath each path segment indicate whether or not the segment is included in the path.
   Specifically, 1 indicates that the segment contributes to the path, while 0 indicates otherwise.
-- As shown above, :code:`'1,0n'` is a segment that is needed in our tiny maze path
-- Hence, the path from start to end is :code:`'0,0n' -> '1,0n' -> '1,0w'`
+- As shown above, ``'1,0n'`` is a segment that is needed in our tiny maze path
+- Hence, the path from start to end is ``'0,0n' -> '1,0n' -> '1,0w'``
 
 

--- a/maze/README.rst
+++ b/maze/README.rst
@@ -23,7 +23,7 @@ Usage
   python demo.py
 
 Returns ASCII visual of the maze and a QPU sampled maze path. As well, there is
-a print out of the path segments and their associated boolean value (see "Code
+a printout of the path segments and their associated boolean value (see "Code
 Specifics - Interpreting Results" for details).
  
 Code Overview
@@ -56,7 +56,7 @@ The maze is a rectangular grid. The path segments (aka edges) that can be
 formed in this grid are described with respect to a grid point. For example,
 the edge labelled ``'1,0w'``:
 
-- ``1,0`` refers to grid point on row 1, column 0
+- ``1,0`` refers to a grid point on row 1, column 0
 - ``w`` refers to "west"
 
 Hence, if you imagine a compass that is centered at position ``1,0``, the edge

--- a/maze/README.rst
+++ b/maze/README.rst
@@ -5,6 +5,24 @@ Getting the D-Wave quantum computer to solve a maze!
 The following code takes a simple and familiar problem---solving a maze---and
 demonstrates the steps of submitting such problems to the quantum computer.
 
+::
+  #|#######
+  #._._. .#
+  #  # |  #
+  #. . ._.#
+  #      |#
+  #. .#. ._
+  #########
+
+Usage
+-----
+::
+  python demo.py
+
+Returns ascii visual of the maze and a QPU sampled maze path. As well, there is
+a print out of the path segments and their associated boolean value (i.e. is
+the path segment selected? ``True (1)`` or ``False (0)``).
+ 
 Code Overview
 -------------
 The solution technique is to construct a set of constraints that enforces the

--- a/maze/README.rst
+++ b/maze/README.rst
@@ -82,12 +82,13 @@ Consider the following 2 by 2 maze with
 - end = ``'1,0w'``
 - walls = ``['1,1n']``
 
-This can be visualized as the following maze:
+This can be visualized as the following maze. Note that the periods (`.`) act
+as gridpoints, which means that the maze below has 2 rows and 2 columns.
 ::
-  #|###	    <-- start location
+  #|###	    <-- start location (`'0,0n'`); the path "north" of coordinate `0,0`
   #. .#
-  #  ##     <-- wall
-  _. .#     <-- end location
+  #  ##     <-- wall (`'1,1n'`); blocks the path "north" of coordinate `1,1`
+  _. .#     <-- end location; the path "west" of coordinate `1,0`
   #####
 
 When running the demo code and submitting this problem, the following result

--- a/maze/README.rst
+++ b/maze/README.rst
@@ -23,7 +23,7 @@ Usage
   python demo.py
 
 Returns ascii visual of the maze and a QPU sampled maze path. As well, there is
-a print out of the path segments and their associated boolean value ("Code
+a print out of the path segments and their associated boolean value (see "Code
 Specifics - Interpreting Results" for details).
  
 Code Overview

--- a/maze/README.rst
+++ b/maze/README.rst
@@ -44,11 +44,8 @@ There are several constraints involved with a maze:
 - Path cannot pass maze borders
 - Path cannot pass through the internal walls of the maze
 
-Each of these constraints are implemented by the ``maze`` functions:
-``_apply_valid_move_constraint()``, ``_set_start_and_end()``,
-``_set_borders()``, and ``_set_inner_walls()``, respectively. These functions
-are called when the user calls ``get_maze_bqm(..)`` in the Example section
-below.
+Each of these constraints get implemented when the user calls Maze's
+``get_bqm()``.
 
 Code Specifics
 --------------

--- a/maze/README.rst
+++ b/maze/README.rst
@@ -13,8 +13,10 @@ demonstrates the steps of submitting such problems to the quantum computer.
   #. .#. ._
   #########
 
-The above ASCII figure is a visualization of a maze and the path through said
-maze.
+The above ASCII figure is a visualization of a maze and a maze path returned as
+samples from the QPU. The hashes (`#`) represent maze walls, the pipes (`|`)
+and underscores (`_`) mark the maze path, and the periods (`.`) act as
+gridpoints for this maze.
 
 Usage
 -----

--- a/maze/README.rst
+++ b/maze/README.rst
@@ -13,7 +13,7 @@ demonstrates the steps of submitting such problems to the quantum computer.
   #. .#. ._
   #########
 
-The above ascii figure is a visualization of a maze and the path through said
+The above ASCII figure is a visualization of a maze and the path through said
 maze.
 
 Usage
@@ -22,7 +22,7 @@ Usage
 
   python demo.py
 
-Returns ascii visual of the maze and a QPU sampled maze path. As well, there is
+Returns ASCII visual of the maze and a QPU sampled maze path. As well, there is
 a print out of the path segments and their associated boolean value (see "Code
 Specifics - Interpreting Results" for details).
  

--- a/maze/README.rst
+++ b/maze/README.rst
@@ -13,14 +13,17 @@ demonstrates the steps of submitting such problems to the quantum computer.
   #. .#. ._
   #########
 
+The above ascii figure is a visualization of a maze and the path through said
+maze.
+
 Usage
 -----
 .. code-block :: python
   python demo.py
 
 Returns ascii visual of the maze and a QPU sampled maze path. As well, there is
-a print out of the path segments and their associated boolean value (i.e. is
-the path segment selected? ``True (1)`` or ``False (0)``).
+a print out of the path segments and their associated boolean value ("Code
+Specifics - Interpreting Results" for details).
  
 Code Overview
 -------------
@@ -46,6 +49,8 @@ below.
 
 Code Specifics
 --------------
+Coordinate Notation
+~~~~~~~~~~~~~~~~~~~
 The maze is a rectangular grid. The path segments (aka edges) that can be
 formed in this grid are described with respect to a grid point. For example,
 the edge labelled ``'1,0w'``:
@@ -66,40 +71,39 @@ south or east directions can be restated as edges in north and west directions:
   '<row>,<col>s' == '<row+1>,<col>n'
   '<row>,<col>e' == '<row>,<col+1>w'
 
-Example
--------
-.. code-block:: python
+Result Interpretation
+~~~~~~~~~~~~~~~~~~~~~
+Consider the following 2 by 2 maze with
+ 
+- start = ``'0,0n'``
+- end = ``'1,0w'``
+- walls = ``['1,1n']``
 
-  from maze import get_maze_bqm
-  from dwave.system.samplers import DWaveSampler
-  from dwave.system.composites import EmbeddingComposite
+This can be visualized as the following maze:
+::
+  #|###		<-- start location
+  #. .#
+  #  ##     <-- wall
+  _. .#     <-- end location
+  #####
 
-  # Create maze
-  n_rows = 2
-  n_cols = 2
-  start = '0,0n'
-  end = '1,0w'
-  walls = ['1,1n']
-
-  # Get BQM
-  bqm = get_maze_bqm(n_rows, n_cols, start, end, walls)
-
-  # Submit BQM to a D-Wave sampler
-  sampler = EmbeddingComposite(DWaveSampler())
-  result = sampler.sample(bqm, num_reads=1000)
-  print(result)
-
-.. code-block:: none
-
+When running the demo code and submitting this problem, the following result
+would be produced:
+::
+  #|###
+  #. .#
+  #| ##
+  _. .#
+  #####
+ 
      1,0n  0,1w  1,1w  energy  num_occ.  chain_b.
   0     1     0     0    -3.5      1000       0.0
 
-Printed results:
+Comments on the printed result:
 
 - The 1s and 0s beneath each path segment indicate whether or not the
   segment is included in the path. Specifically, 1 indicates that the segment
   contributes to the path, while 0 indicates otherwise.
 - As shown above, ``'1,0n'`` is a segment that is needed in our tiny maze path
 - Hence, the path from start to end is ``'0,0n' -> '1,0n' -> '1,0w'``
-
 

--- a/maze/README.rst
+++ b/maze/README.rst
@@ -19,6 +19,7 @@ maze.
 Usage
 -----
 .. code-block :: python
+
   python demo.py
 
 Returns ascii visual of the maze and a QPU sampled maze path. As well, there is

--- a/maze/README.rst
+++ b/maze/README.rst
@@ -81,7 +81,7 @@ Consider the following 2 by 2 maze with
 
 This can be visualized as the following maze:
 ::
-  #|###		<-- start location
+  #|###	    <-- start location
   #. .#
   #  ##     <-- wall
   _. .#     <-- end location

--- a/maze/README.rst
+++ b/maze/README.rst
@@ -2,42 +2,47 @@ Demo of Maze Solving
 ====================
 Getting the D-Wave quantum computer to solve a maze!
 
-The following code takes a simple and familiar problem---solving a maze---and demonstrates the steps
-of submitting such problems to the quantum computer.
+The following code takes a simple and familiar problem---solving a maze---and
+demonstrates the steps of submitting such problems to the quantum computer.
 
 Code Overview
 -------------
-The solution technique is to construct a set of constraints that enforces the rules of moving
-through a maze. These constraints are then converted by Ocean software tools to a binary
-quadratic model (BQM) that can then be solved with a D-Wave quantum computer. The solution that gets
-returned by the quantum computer is the path needed to get through the maze.
+The solution technique is to construct a set of constraints that enforces the
+rules of moving through a maze. These constraints are then converted by Ocean
+software tools to a binary quadratic model (BQM) that can then be solved with
+a D-Wave quantum computer. The solution that gets returned by the quantum
+computer is the path needed to get through the maze.
 
 There are several constraints involved with a maze:
 
-- Valid path movements (i.e., if the path enters a grid point, it must also leave said grid point)
+- Valid path movements (i.e., if the path enters a grid point, it must also
+  leave said grid point)
 - Path has a specific start and end position
 - Path cannot pass maze borders
 - Path cannot pass through the internal walls of the maze
 
 Each of these constraints are implemented by the ``maze`` functions:
-``_apply_valid_move_constraint()``, ``_set_start_and_end()``, ``_set_borders()``, and
-``_set_inner_walls()``, respectively. These functions are called when the user calls
-``get_maze_bqm(..)`` in the Example section below.
+``_apply_valid_move_constraint()``, ``_set_start_and_end()``,
+``_set_borders()``, and ``_set_inner_walls()``, respectively. These functions
+are called when the user calls ``get_maze_bqm(..)`` in the Example section
+below.
 
 Code Specifics
 --------------
-The maze is a rectangular grid. The path segments (aka edges) that can be formed in this grid are
-described with respect to a grid point. For example, the edge labelled ``'1,0w'``:
+The maze is a rectangular grid. The path segments (aka edges) that can be
+formed in this grid are described with respect to a grid point. For example,
+the edge labelled ``'1,0w'``:
 
 - ``1,0`` refers to grid point on row 1, column 0
 - ``w`` refers to "west"
 
-Hence, if you imagine a compass that is centered at position ``1,0``, the edge ``'1,0w'``
-is the path segment that sits along the western direction of this compass.
+Hence, if you imagine a compass that is centered at position ``1,0``, the edge
+``'1,0w'`` is the path segment that sits along the western direction of this
+compass.
 
-Note that the code only accepts edge inputs in the north direction (``'<row>,<col>n'``) and the
-west direction (``'<row>,<col>w'``). Edges in south or east directions can be restated as edges
-in north and west directions:
+Note that the code only accepts edge inputs in the north direction
+(``'<row>,<col>n'``) and the west direction (``'<row>,<col>w'``). Edges in
+south or east directions can be restated as edges in north and west directions:
 
 .. code-block:: none
 
@@ -74,8 +79,9 @@ Example
 
 Printed results:
 
-- The 1s and 0s beneath each path segment indicate whether or not the segment is included in the path.
-  Specifically, 1 indicates that the segment contributes to the path, while 0 indicates otherwise.
+- The 1s and 0s beneath each path segment indicate whether or not the
+  segment is included in the path. Specifically, 1 indicates that the segment
+  contributes to the path, while 0 indicates otherwise.
 - As shown above, ``'1,0n'`` is a segment that is needed in our tiny maze path
 - Hence, the path from start to end is ``'0,0n' -> '1,0n' -> '1,0w'``
 

--- a/maze/README.rst
+++ b/maze/README.rst
@@ -4,7 +4,6 @@ Getting the D-Wave quantum computer to solve a maze!
 
 The following code takes a simple and familiar problem---solving a maze---and
 demonstrates the steps of submitting such problems to the quantum computer.
-
 ::
   #|#######
   #._._. .#
@@ -16,7 +15,7 @@ demonstrates the steps of submitting such problems to the quantum computer.
 
 Usage
 -----
-::
+.. code-block :: python
   python demo.py
 
 Returns ascii visual of the maze and a QPU sampled maze path. As well, there is

--- a/maze/demo.py
+++ b/maze/demo.py
@@ -16,7 +16,7 @@ m = Maze(n_rows, n_cols, start, end, walls)
 bqm = m.get_bqm()
 
 # Submit BQM to a D-Wave sampler
-# Note: when grabbing the solution, we are only grabbing path segments that have
+# Note: when grabbing the path, we are only grabbing path segments that have
 #   been "selected" (i.e. indicated with a 1).
 # Note2: in order to get the BQM at the right energy levels, auxiliary variables
 #   may have been included in the BQM. These auxiliary variables are no longer
@@ -24,10 +24,10 @@ bqm = m.get_bqm()
 #   them out with regex (i.e. re.match(r"^aux(\d+)$", k)])
 sampler = EmbeddingComposite(DWaveSampler())
 result = sampler.sample(bqm, num_reads=1000)
-solution = [k for k, v in result.first.sample.items() if v==1
-            and re.match(r"^aux(\d+)$", k)]
+path = [k for k, v in result.first.sample.items() if v==1
+            and not re.match(r"^aux(\d+)$", k)]
 
 # Visualize maze solution
-m.visualize(solution)
+m.visualize(path)
 print("\n")
 print(result)

--- a/maze/demo.py
+++ b/maze/demo.py
@@ -1,6 +1,8 @@
-from maze import get_maze_bqm, Maze
 from dwave.system.samplers import DWaveSampler
 from dwave.system.composites import EmbeddingComposite
+import re
+
+from maze import get_maze_bqm, Maze
 
 # Create maze
 n_rows = 2
@@ -14,10 +16,18 @@ m = Maze(n_rows, n_cols, start, end, walls)
 bqm = m.get_bqm()
 
 # Submit BQM to a D-Wave sampler
+# Note: when grabbing the solution, we are only grabbing path segments that have
+#   been "selected" (i.e. indicated with a 1).
+# Note2: in order to get the BQM at the right energy levels, auxiliary variables
+#   may have been included in the BQM. These auxiliary variables are no longer
+#   useful once we have our result. Hence, we can just ignore them by filtering
+#   them out with regex (i.e. re.match(r"^aux(\d+)$", k)])
 sampler = EmbeddingComposite(DWaveSampler())
 result = sampler.sample(bqm, num_reads=1000)
-solution = [k for k, v in result.first.sample.items() if v==1]
+solution = [k for k, v in result.first.sample.items() if v==1
+            and re.match(r"^aux(\d+)$", k)]
 
 # Visualize maze solution
 m.visualize(solution)
+print("\n")
 print(result)

--- a/maze/demo.py
+++ b/maze/demo.py
@@ -1,3 +1,17 @@
+# Copyright 2019 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dwave.system.samplers import DWaveSampler
 from dwave.system.composites import EmbeddingComposite
 import re

--- a/maze/demo.py
+++ b/maze/demo.py
@@ -21,11 +21,11 @@ from maze import get_maze_bqm, Maze
 # Create maze
 n_rows = 3
 n_cols = 4
-start = '0,0n'  # maze entrance location
-end = '2,4w'    # maze exit location
+start = '0,0n'              # maze entrance location
+end = '2,4w'                # maze exit location
 walls = ['1,1n', '2,2w']    # maze interior wall locations
 
-# Get BQM
+# Construct BQM
 m = Maze(n_rows, n_cols, start, end, walls)
 bqm = m.get_bqm()
 
@@ -39,7 +39,8 @@ result = sampler.sample(bqm, num_reads=1000, chain_strength=2)
 # Interpret result
 # Note: when grabbing the path, we are only grabbing path segments that have
 #   been "selected" (i.e. indicated with a 1).
-# Note2: in order to get the BQM at the right energy levels, auxiliary variables
+# Note2: in order construct the BQM such that the maze solution corresponds to
+#   the ground energy, auxiliary variables
 #   may have been included in the BQM. These auxiliary variables are no longer
 #   useful once we have our result. Hence, we can just ignore them by filtering
 #   them out with regex (i.e. re.match(r"^aux(\d+)$", k)])

--- a/maze/demo.py
+++ b/maze/demo.py
@@ -11,11 +11,13 @@ walls = ['1,1n']
 
 # Get BQM
 m = Maze(n_rows, n_cols, start, end, walls)
-bqm = get_maze_bqm(n_rows, n_cols, start, end, walls)
+bqm = m.get_bqm()
 
 # Submit BQM to a D-Wave sampler
 sampler = EmbeddingComposite(DWaveSampler())
 result = sampler.sample(bqm, num_reads=1000)
 solution = [k for k, v in result.first.sample.items() if v==1]
+
+# Visualize maze solution
 m.visualize(solution)
 print(result)

--- a/maze/demo.py
+++ b/maze/demo.py
@@ -1,4 +1,4 @@
-from maze import get_maze_bqm
+from maze import get_maze_bqm, Maze
 from dwave.system.samplers import DWaveSampler
 from dwave.system.composites import EmbeddingComposite
 
@@ -10,9 +10,12 @@ end = '1,0w'
 walls = ['1,1n']
 
 # Get BQM
+m = Maze(n_rows, n_cols, start, end, walls)
 bqm = get_maze_bqm(n_rows, n_cols, start, end, walls)
 
 # Submit BQM to a D-Wave sampler
 sampler = EmbeddingComposite(DWaveSampler())
 result = sampler.sample(bqm, num_reads=1000)
+solution = [k for k, v in result.first.sample.items() if v==1]
+m.visualize(solution)
 print(result)

--- a/maze/demo.py
+++ b/maze/demo.py
@@ -30,9 +30,14 @@ m = Maze(n_rows, n_cols, start, end, walls)
 bqm = m.get_bqm()
 
 # Submit BQM to a D-Wave sampler
-# Note: the values of num_reads and chain_strength were arbitrarily picked. They
-#   just needed to be slightly higher than the default values in order to get
-#   this demo to produce the correct solution.
+# Note: occasionally, multiple qubits are used to represent a single variable
+#   (e.g. using multiple qubits to represent a single path segment in a maze).
+#   The reason for this representation has to do with the way the quantum
+#   computing hardware is structured. In order to get this set of qubits
+#   - known as a chain - to each produce same result for the single variable,
+#   we add weights to them such that this behaviour is becomes more likely.
+#   Below, we have slightly increased the default chain strength in order to
+#   help maintain the chain during sampling.
 sampler = EmbeddingComposite(DWaveSampler())
 result = sampler.sample(bqm, num_reads=1000, chain_strength=2)
 

--- a/maze/demo.py
+++ b/maze/demo.py
@@ -5,29 +5,34 @@ import re
 from maze import get_maze_bqm, Maze
 
 # Create maze
-n_rows = 2
-n_cols = 2
+n_rows = 3
+n_cols = 4
 start = '0,0n'
-end = '1,0w'
-walls = ['1,1n']
+end = '2,4w'
+walls = ['1,1n', '2,2w']
 
 # Get BQM
 m = Maze(n_rows, n_cols, start, end, walls)
 bqm = m.get_bqm()
 
 # Submit BQM to a D-Wave sampler
+# Note: the values of num_reads and chain_strength were arbitrarily picked. They
+#   just needed to be slightly higher than the default values in order to get
+#   this demo to produce the correct solution.
+sampler = EmbeddingComposite(DWaveSampler())
+result = sampler.sample(bqm, num_reads=1000, chain_strength=2)
+
+# Interpret result
 # Note: when grabbing the path, we are only grabbing path segments that have
 #   been "selected" (i.e. indicated with a 1).
 # Note2: in order to get the BQM at the right energy levels, auxiliary variables
 #   may have been included in the BQM. These auxiliary variables are no longer
 #   useful once we have our result. Hence, we can just ignore them by filtering
 #   them out with regex (i.e. re.match(r"^aux(\d+)$", k)])
-sampler = EmbeddingComposite(DWaveSampler())
-result = sampler.sample(bqm, num_reads=1000)
 path = [k for k, v in result.first.sample.items() if v==1
             and not re.match(r"^aux(\d+)$", k)]
 
-# Visualize maze solution
+# Visualize maze path
 m.visualize(path)
 print("\n")
-print(result)
+print(result.first.sample)

--- a/maze/demo.py
+++ b/maze/demo.py
@@ -21,9 +21,9 @@ from maze import get_maze_bqm, Maze
 # Create maze
 n_rows = 3
 n_cols = 4
-start = '0,0n'
-end = '2,4w'
-walls = ['1,1n', '2,2w']
+start = '0,0n'  # maze entrance location
+end = '2,4w'    # maze exit location
+walls = ['1,1n', '2,2w']    # maze interior wall locations
 
 # Get BQM
 m = Maze(n_rows, n_cols, start, end, walls)

--- a/maze/demo.py
+++ b/maze/demo.py
@@ -30,14 +30,6 @@ m = Maze(n_rows, n_cols, start, end, walls)
 bqm = m.get_bqm()
 
 # Submit BQM to a D-Wave sampler
-# Note: occasionally, multiple qubits are used to represent a single variable
-#   (e.g. using multiple qubits to represent a single path segment in a maze).
-#   The reason for this representation has to do with the way the quantum
-#   computing hardware is structured. In order to get this set of qubits
-#   - known as a chain - to each produce same result for the single variable,
-#   we add weights to them such that this behaviour is becomes more likely.
-#   Below, we have slightly increased the default chain strength in order to
-#   help maintain the chain during sampling.
 sampler = EmbeddingComposite(DWaveSampler())
 result = sampler.sample(bqm, num_reads=1000, chain_strength=2)
 

--- a/maze/demo.py
+++ b/maze/demo.py
@@ -1,0 +1,18 @@
+from maze import get_maze_bqm
+from dwave.system.samplers import DWaveSampler
+from dwave.system.composites import EmbeddingComposite
+
+# Create maze
+n_rows = 2
+n_cols = 2
+start = '0,0n'
+end = '1,0w'
+walls = ['1,1n']
+
+# Get BQM
+bqm = get_maze_bqm(n_rows, n_cols, start, end, walls)
+
+# Submit BQM to a D-Wave sampler
+sampler = EmbeddingComposite(DWaveSampler())
+result = sampler.sample(bqm, num_reads=1000)
+print(result)

--- a/maze/maze.py
+++ b/maze/maze.py
@@ -187,7 +187,7 @@ class Maze:
         # Edit bqm to favour optimal solutions
         for v in bqm.variables:
             # Ignore auxiliary variables
-            if isinstance(v, str) and re.match(r'aux\d+$', v):
+            if isinstance(v, str) and re.match(r'^aux\d+$', v):
                 continue
 
             # Add a penalty to every tile of the path
@@ -197,7 +197,7 @@ class Maze:
 
     def visualize(self, solution=None):
         def get_visual_coords(coords):
-            coord_pattern = "(\d+),(\d+)([nw])"
+            coord_pattern = "^(\d+),(\d+)([nw])$"
             row, col, dir = re.findall(coord_pattern, coords)[0]
             new_row, new_col = map(lambda x: int(x) * 2 + 1, [row, col])
             new_row, new_col = (new_row-1, new_col) if dir == "n" else (new_row, new_col-1)
@@ -216,6 +216,16 @@ class Maze:
             solution = []
 
         # Construct empty maze visual
+        # Note: the maze visual is (2 * original-maze-dimension + 1) because
+        #   each position has an associated north-edge and an associated
+        #   west-edge. This requires two rows and two columns to draw,
+        #   respectively. Thus, the "2 * original-maze-dimension" is needed.
+        #      |      <-- north edge
+        #     _.      <-- west edge and position
+        #   To get a south-edge or a east-edge, the north-edge from the row
+        #   below or the west-edge from the column on the right could be used
+        #   respectively. This trick, however, cannot be used for the last row
+        #   nor for the rightmost column, hence the "+ 1" in the equation.
         width = 2*self.n_cols + 1       # maze visual's width
         height = 2*self.n_rows + 1      # maze visual's height
 
@@ -227,6 +237,9 @@ class Maze:
         visual[-1] = [WALL] * width     # bottom border
 
         # Add coordinate positions in maze visual
+        # Note: the symbol POS appears at every other position because there
+        #   could potentially be a path segment sitting between the two
+        #   positions.
         for position_row in visual[1::2]:
             position_row[1::2] = [POS]*(self.n_cols - 1) + [POS]
 

--- a/maze/maze.py
+++ b/maze/maze.py
@@ -202,7 +202,14 @@ class Maze:
             new_row, new_col = map(lambda x: int(x) * 2 + 1, [row, col])
             new_row, new_col = (new_row-1, new_col) if dir == "n" else (new_row, new_col-1)
 
-            return new_row, new_col
+            return new_row, new_col, dir
+
+        # Constants for maze symbols
+        WALL = "#"      # maze wall
+        NS = "|"        # path going in north-south direction
+        EW = "_"        # path going in east-west direction
+        POS = "."       # coordinate position
+        EMPTY = " "     # whitespace; indicates no path drawn
 
         # Check parameters
         if solution is None:
@@ -223,20 +230,20 @@ class Maze:
             position_row[1::2] = ["."]*(self.n_cols - 1) + ["."]
 
         # Add maze start and end to visual
-        start_row, start_col = get_visual_coords(self.start)
-        end_row, end_col = get_visual_coords(self.end)
-        visual[start_row][start_col] = "s"
-        visual[end_row][end_col] = "e"
+        start_row, start_col, start_dir = get_visual_coords(self.start)
+        end_row, end_col, end_dir = get_visual_coords(self.end)
+        visual[start_row][start_col] = "|" if start_dir=="n" else "_"
+        visual[end_row][end_col] = "|" if end_dir=="n" else "_"
 
         # Add interior walls to visual
         for w in self.walls:
-            row, col = get_visual_coords(w)
+            row, col, _ = get_visual_coords(w)
             visual[row][col] = "#"
 
         # Add solution path to visual
         for s in solution:
-            row, col = get_visual_coords(s)
-            visual[row][col] = "*"
+            row, col, dir = get_visual_coords(s)
+            visual[row][col] = "|" if dir=="n" else "_"
 
         # Print solution
         for s in visual:

--- a/maze/maze.py
+++ b/maze/maze.py
@@ -218,6 +218,7 @@ class Maze:
         # Construct empty maze visual
         width = 2*self.n_cols + 1       # maze visual's width
         height = 2*self.n_rows + 1      # maze visual's height
+
         empty_row = [EMPTY] * (width-2)
         empty_row = [WALL] + empty_row + [WALL]   # add left and right borders
 
@@ -225,15 +226,15 @@ class Maze:
         visual[0] = [WALL] * width      # top border
         visual[-1] = [WALL] * width     # bottom border
 
-        # Add possible locations in maze visual
+        # Add coordinate positions in maze visual
         for position_row in visual[1::2]:
             position_row[1::2] = [POS]*(self.n_cols - 1) + [POS]
 
         # Add maze start and end to visual
         start_row, start_col, start_dir = get_visual_coords(self.start)
         end_row, end_col, end_dir = get_visual_coords(self.end)
-        visual[start_row][start_col] = NS if start_dir == "n" else EW
-        visual[end_row][end_col] = NS if end_dir == "n" else EW
+        visual[start_row][start_col] = NS if start_dir=="n" else EW
+        visual[end_row][end_col] = NS if end_dir=="n" else EW
 
         # Add interior walls to visual
         for w in self.walls:
@@ -243,7 +244,7 @@ class Maze:
         # Add solution path to visual
         for s in solution:
             row, col, dir = get_visual_coords(s)
-            visual[row][col] = NS if dir == "n" else EW
+            visual[row][col] = NS if dir=="n" else EW
 
         # Print solution
         for s in visual:

--- a/maze/maze.py
+++ b/maze/maze.py
@@ -222,8 +222,8 @@ class Maze:
         #   respectively. Thus, the "2 * original-maze-dimension" is needed.
         #      |      <-- north edge
         #     _.      <-- west edge and position
-        #   To get a south-edge or a east-edge, the north-edge from the row
-        #   below or the west-edge from the column on the right could be used
+        #   To get a south-edge or an east-edge, the north-edge from the row
+        #   below or the west-edge from the column on the right can be used
         #   respectively. This trick, however, cannot be used for the last row
         #   nor for the rightmost column, hence the "+ 1" in the equation.
         width = 2*self.n_cols + 1       # maze visual's width
@@ -241,7 +241,7 @@ class Maze:
         #   could potentially be a path segment sitting between the two
         #   positions.
         for position_row in visual[1::2]:
-            position_row[1::2] = [POS]*(self.n_cols - 1) + [POS]
+            position_row[1::2] = [POS] * self.n_cols
 
         # Add maze start and end to visual
         start_row, start_col, start_dir = get_visual_coords(self.start)

--- a/maze/maze.py
+++ b/maze/maze.py
@@ -208,14 +208,19 @@ class Maze:
         if solution is None:
             solution = []
 
-        # Set up default maze values
-        # Note: using list(..) to get a copy of the list, rather than get a reference to the list
-        horizontal_border = ["#"] * (2*self.n_cols + 1)
-        default_row = [" "] * (2*self.n_cols - 1)
-        default_row = ["#"] + default_row + ["#"]       # adding maze borders
-        visual = [list(default_row) for _ in range(2*self.n_rows - 1)]
-        visual.insert(0, list(horizontal_border))
-        visual.append(list(horizontal_border))
+        # Construct empty maze visual
+        width = 2*self.n_cols + 1       # maze visual's width
+        height = 2*self.n_rows + 1      # maze visual's height
+        empty_row = [" "] * (width-2)
+        empty_row = ["#"] + empty_row + ["#"]   # add left and right borders
+
+        visual = [list(empty_row) for _ in range(height)]
+        visual[0] = ["#"] * width      # top border
+        visual[-1] = ["#"] * width     # bottom border
+
+        # Add possible locations in maze visual
+        for position_row in visual[1::2]:
+            position_row[1::2] = ["."]*(self.n_cols - 1) + ["."]
 
         # Add maze start and end to visual
         start_row, start_col = get_visual_coords(self.start)

--- a/maze/maze.py
+++ b/maze/maze.py
@@ -196,6 +196,18 @@ class Maze:
         return bqm
 
     def visualize(self, solution=None):
+        def get_visual_coords(coords):
+            coord_pattern = "(\d+),(\d+)([nw])"
+            row, col, dir = re.findall(coord_pattern, coords)[0]
+            new_row, new_col = map(lambda x: int(x) * 2 + 1, [row, col])
+            new_row, new_col = (new_row-1, new_col) if dir == "n" else (new_row, new_col-1)
+
+            return new_row, new_col
+
+        # Check parameters
+        if solution is None:
+            solution = []
+
         # Set up default maze values
         # Note: using list(..) to get a copy of the list, rather than get a reference to the list
         horizontal_border = ["#"] * (2*self.n_cols + 1)
@@ -205,23 +217,22 @@ class Maze:
         visual.insert(0, list(horizontal_border))
         visual.append(list(horizontal_border))
 
-        # Add in maze start, end, and interior walls
-        coord_pattern = "(\d+),(\d+)([nw])"
-        start_row, start_col, start_dir = re.findall(coord_pattern, self.start)[0]
-        start_row = int(start_row)
-        start_col = int(start_col)
-        start_row, start_col = (start_row-1, start_col) if start_dir=="n" else (start_row, start_col-1)
-
-        #end_row, end_col, end_dir = re.findall(coord_pattern, self.end)[0]
-        #end_row, end_col = (end_row-1, end_col) if end_dir=="n" else (end_row, end_col-1)
+        # Add maze start and end to visual
+        start_row, start_col = get_visual_coords(self.start)
+        end_row, end_col = get_visual_coords(self.end)
         visual[start_row][start_col] = "s"
+        visual[end_row][end_col] = "e"
 
-        # Add in solution
+        # Add interior walls to visual
+        for w in self.walls:
+            row, col = get_visual_coords(w)
+            visual[row][col] = "#"
+
+        # Add solution path to visual
+        for s in solution:
+            row, col = get_visual_coords(s)
+            visual[row][col] = "*"
 
         # Print solution
         for s in visual:
             print("".join(s))
-
-
-
-

--- a/maze/maze.py
+++ b/maze/maze.py
@@ -218,32 +218,32 @@ class Maze:
         # Construct empty maze visual
         width = 2*self.n_cols + 1       # maze visual's width
         height = 2*self.n_rows + 1      # maze visual's height
-        empty_row = [" "] * (width-2)
-        empty_row = ["#"] + empty_row + ["#"]   # add left and right borders
+        empty_row = [EMPTY] * (width-2)
+        empty_row = [WALL] + empty_row + [WALL]   # add left and right borders
 
         visual = [list(empty_row) for _ in range(height)]
-        visual[0] = ["#"] * width      # top border
-        visual[-1] = ["#"] * width     # bottom border
+        visual[0] = [WALL] * width      # top border
+        visual[-1] = [WALL] * width     # bottom border
 
         # Add possible locations in maze visual
         for position_row in visual[1::2]:
-            position_row[1::2] = ["."]*(self.n_cols - 1) + ["."]
+            position_row[1::2] = [POS]*(self.n_cols - 1) + [POS]
 
         # Add maze start and end to visual
         start_row, start_col, start_dir = get_visual_coords(self.start)
         end_row, end_col, end_dir = get_visual_coords(self.end)
-        visual[start_row][start_col] = "|" if start_dir=="n" else "_"
-        visual[end_row][end_col] = "|" if end_dir=="n" else "_"
+        visual[start_row][start_col] = NS if start_dir == "n" else EW
+        visual[end_row][end_col] = NS if end_dir == "n" else EW
 
         # Add interior walls to visual
         for w in self.walls:
             row, col, _ = get_visual_coords(w)
-            visual[row][col] = "#"
+            visual[row][col] = WALL
 
         # Add solution path to visual
         for s in solution:
             row, col, dir = get_visual_coords(s)
-            visual[row][col] = "|" if dir=="n" else "_"
+            visual[row][col] = NS if dir == "n" else EW
 
         # Print solution
         for s in visual:

--- a/maze/maze.py
+++ b/maze/maze.py
@@ -195,6 +195,33 @@ class Maze:
 
         return bqm
 
+    def visualize(self, solution=None):
+        # Set up default maze values
+        # Note: using list(..) to get a copy of the list, rather than get a reference to the list
+        horizontal_border = ["#"] * (2*self.n_cols + 1)
+        default_row = [" "] * (2*self.n_cols - 1)
+        default_row = ["#"] + default_row + ["#"]       # adding maze borders
+        visual = [list(default_row) for _ in range(2*self.n_rows - 1)]
+        visual.insert(0, list(horizontal_border))
+        visual.append(list(horizontal_border))
+
+        # Add in maze start, end, and interior walls
+        coord_pattern = "(\d+),(\d+)([nw])"
+        start_row, start_col, start_dir = re.findall(coord_pattern, self.start)[0]
+        start_row = int(start_row)
+        start_col = int(start_col)
+        start_row, start_col = (start_row-1, start_col) if start_dir=="n" else (start_row, start_col-1)
+
+        #end_row, end_col, end_dir = re.findall(coord_pattern, self.end)[0]
+        #end_row, end_col = (end_row-1, end_col) if end_dir=="n" else (end_row, end_col-1)
+        visual[start_row][start_col] = "s"
+
+        # Add in solution
+
+        # Print solution
+        for s in visual:
+            print("".join(s))
+
 
 
 

--- a/maze/test_maze.py
+++ b/maze/test_maze.py
@@ -313,11 +313,9 @@ class TestGetMazeBqm(unittest.TestCase):
         self.assertIsInstance(bqm, BinaryQuadraticModel)
 
 class TestMazeVisualization(unittest.TestCase):
-    def test_empty(self):
-        #m = Maze(0, 0, "", "", [])
-        pass
-
     def test_maze_setup(self):
+        """Test that the maze setup is visualized correctly
+        """
         m = Maze(3, 2, "2,0w", "0,1n", ["0,1w", "1,1w", "2,0n"])
         expected_out = ("###|#\n" 
                         "#.#.#\n"
@@ -327,20 +325,29 @@ class TestMazeVisualization(unittest.TestCase):
                         "_. .#\n"
                         "#####\n")
 
+        # Replace sys.stdout with mock
         with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
             m.visualize()
             self.assertEqual(mock_stdout.getvalue(), expected_out)
 
     def test_maze_solution(self):
-        m = Maze(3, 3, "", "", [])
-        expected_out = ("###|###
-#. . .#\n"
-#     #\n"
-#. . .#
-#     #
-_. . .#
-#######
-"
+        """Test that the maze path is visualized correctly
+        """
+        m = Maze(3, 3, "2,0w", "0,3w", ["1,2n", "2,0n", "2,1n"])
+        path = ["2,1w", "2,2w", "2,2n", "1,2w", "1,1w", "1,0n", "0,1w", "0,2w"]
+        expected_out = ("#######\n"
+                        "#._._._\n"
+                        "#|   ##\n"
+                        "#._._.#\n"
+                        "## # |#\n"
+                        "_._._.#\n"
+                        "#######\n")
+
+        # Replace sys.stdout with mock
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            m.visualize(path)
+            self.assertEqual(mock_stdout.getvalue(), expected_out)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/maze/test_maze.py
+++ b/maze/test_maze.py
@@ -312,6 +312,7 @@ class TestGetMazeBqm(unittest.TestCase):
         bqm = get_maze_bqm(n_rows, n_cols, start, end, walls)
         self.assertIsInstance(bqm, BinaryQuadraticModel)
 
+
 class TestMazeVisualization(unittest.TestCase):
     def test_maze_setup(self):
         """Test that the maze setup is visualized correctly

--- a/maze/test_maze.py
+++ b/maze/test_maze.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 import itertools
+import io
 import re
 import unittest
 
 from dimod import BinaryQuadraticModel
+from unittest.mock import patch
+
 from maze import Maze, get_label, get_maze_bqm
 from neal import SimulatedAnnealingSampler
 
@@ -309,6 +312,35 @@ class TestGetMazeBqm(unittest.TestCase):
         bqm = get_maze_bqm(n_rows, n_cols, start, end, walls)
         self.assertIsInstance(bqm, BinaryQuadraticModel)
 
+class TestMazeVisualization(unittest.TestCase):
+    def test_empty(self):
+        #m = Maze(0, 0, "", "", [])
+        pass
+
+    def test_maze_setup(self):
+        m = Maze(3, 2, "2,0w", "0,1n", ["0,1w", "1,1w", "2,0n"])
+        expected_out = ("###|#\n" 
+                        "#.#.#\n"
+                        "#   #\n"
+                        "#.#.#\n"
+                        "##  #\n"
+                        "_. .#\n"
+                        "#####\n")
+
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            m.visualize()
+            self.assertEqual(mock_stdout.getvalue(), expected_out)
+
+    def test_maze_solution(self):
+        m = Maze(3, 3, "", "", [])
+        expected_out = ("###|###
+#. . .#\n"
+#     #\n"
+#. . .#
+#     #
+_. . .#
+#######
+"
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #88 

- Add `demo.py` so users can just run the demo out-of-the-box
- Add code to visualize the maze with ascii
- Edited README to include the above changes
- Edited README to obey column 80, hence it looks I made a lot of readme changes. (This change occurs in 5195b6e)
- Add test code to check visualization code