### PR TITLE
Feature/improve jss scaling

### DIFF
--- a/job-shop-scheduling/job_shop_scheduler.py
+++ b/job-shop-scheduling/job_shop_scheduler.py
@@ -328,7 +328,7 @@ class JobShopScheduler:
             task = self.tasks[i]
 
             for t in range(self.max_time):
-                end_time = t + task.duration
+                end_time = t + task.duration - 1    # -1 to get last unit of time the task occupies
 
                 # Check task's end time
                 # Note: first condition is to prevent adding in absurd times. Second condition is

--- a/job-shop-scheduling/job_shop_scheduler.py
+++ b/job-shop-scheduling/job_shop_scheduler.py
@@ -339,7 +339,7 @@ class JobShopScheduler:
         Args:
             stitch_kwargs: A dict. Kwargs to be passed to dwavebinarycsp.stitch.
         """
-        if stitch_kwargs == None:
+        if stitch_kwargs is None:
             stitch_kwargs = {}
 
         # Apply constraints to self.csp

--- a/job-shop-scheduling/job_shop_scheduler.py
+++ b/job-shop-scheduling/job_shop_scheduler.py
@@ -139,7 +139,7 @@ class JobShopScheduler:
 
         self.tasks = []
         self.last_task_indices = []
-        self.max_time = max_time - 1    # -1 to account for zero-indexing
+        self.max_time = max_time    # will get decremented by 1 for zero-indexing; see _process_data
         self.csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
 
         # Populates self.tasks and self.max_time
@@ -175,7 +175,8 @@ class JobShopScheduler:
         self.max_job_time = max_job_time - 1    # -1 to account for zero-indexing
 
         if self.max_time is None:
-            self.max_time = total_time - 1    # -1 to account for zero-indexing
+            self.max_time = total_time
+        self.max_time -= 1    # -1 to account for zero-indexing
 
     def _add_one_start_constraint(self):
         """self.csp gets the constraint: A task can start once and only once

--- a/job-shop-scheduling/requirements.txt
+++ b/job-shop-scheduling/requirements.txt
@@ -1,1 +1,4 @@
 dwave-ocean-sdk==1.4.0
+
+# backport
+mock; python_version=="2.7"

--- a/job-shop-scheduling/test_job_shop_scheduler.py
+++ b/job-shop-scheduling/test_job_shop_scheduler.py
@@ -455,8 +455,15 @@ class TestGetBqm(unittest.TestCase):
             bqm = scheduler.get_bqm()
 
         # Check linear biases
-        # Specifically, check that tasks with end-times greater than longest_job are penalized
-        # with biases that encourage shorter schedules
+        # Note: I have grouped the tests by job-task and am comparing the linear biases between
+        #   adjacent times. Tasks that finish before or at the lowerbound of the optimal schedule
+        #   are not penalized with an additional bias; hence all these task-times should have the
+        #   same bias.
+        #   For example, the 0th task of job 2 (aka 'j2_0') will have the same linear
+        #   bias for times 0 through 2 because with these start times, the task would complete
+        #   before the optimal schedule lowerbound. (i.e. "j2_0,0", "j2_0,1", "j2_0,2" all have the
+        #   same linear biases). The remaining task-times will have increasing biases with time, in
+        #   this way, the shortest schedule is encouraged.
         self.assertEqual(bqm.linear['j2_0,0'], bqm.linear['j2_0,1'])
         self.assertEqual(bqm.linear['j2_0,1'], bqm.linear['j2_0,2'])
         self.assertLess(bqm.linear['j2_0,2'], bqm.linear['j2_0,3'])

--- a/job-shop-scheduling/test_job_shop_scheduler.py
+++ b/job-shop-scheduling/test_job_shop_scheduler.py
@@ -232,7 +232,7 @@ class TestJSSExactSolverResponse(unittest.TestCase):
         self.compare(response_sample, expected)
 
     def test_largerSchedule(self):
-        jobs = {'small1': [(1, 1)],
+        jobs = {'small1': [(1, 1), (1, 1)],
                 'small2': [(2, 2)],
                 'longJob': [(0, 1), (1, 1), (2, 1)]}
         max_time = 4
@@ -248,6 +248,7 @@ class TestJSSExactSolverResponse(unittest.TestCase):
 
         # Create expected solution
         expected = {"small1_0,0": 1,
+                    "small1_1,2": 1,
                     "small2_0,0": 1,
                     "longJob_0,0": 1, "longJob_1,1": 1, "longJob_2,2": 1}
 

--- a/job-shop-scheduling/test_job_shop_scheduler.py
+++ b/job-shop-scheduling/test_job_shop_scheduler.py
@@ -430,7 +430,6 @@ class TestGetBqm(unittest.TestCase):
         """
         jobs = {"j1": [("m1", 2), ("m2", 2)],
                 "j2": [("m1", 2)]}
-        longest_job = 4   # Remove hardcode
 
         # Create mock object for stitch(..) output
         linear = {'j1_0,0': -2.0, 'j1_0,1': -2.0, 'j1_0,2': -2.0,

--- a/job-shop-scheduling/test_job_shop_scheduler.py
+++ b/job-shop-scheduling/test_job_shop_scheduler.py
@@ -448,7 +448,8 @@ class TestGetBqm(unittest.TestCase):
                      ('j2_0,2', 'j2_0,1'): 4.0, ('j2_0,2', 'aux0'): 4.0, ('j2_0,4', 'j2_0,0'): 4.0,
                      ('j2_0,4', 'j2_0,1'): 4.0, ('j2_0,4', 'aux0'): 4.0, ('j2_0,0', 'j2_0,1'): 4.0,
                      ('j2_0,0', 'aux0'): 4.0, ('j2_0,1', 'aux0'): 4.0}
-        mock_stitched_bqm = BinaryQuadraticModel(linear, quadratic, 14.0, dbc.BINARY)
+        vartype = dbc.BINARY
+        mock_stitched_bqm = BinaryQuadraticModel(linear, quadratic, 14.0, vartype)
 
         scheduler = JobShopScheduler(jobs)
         with unittest.mock.patch.object(dbc, "stitch", return_value=mock_stitched_bqm):
@@ -469,8 +470,11 @@ class TestGetBqm(unittest.TestCase):
         self.assertLess(bqm.linear['j1_1,3'], bqm.linear['j1_1,4'])
 
         # Check quadratic biases
-        # Specifically, quadratic biases should not be penalized to encourage shorter schedules
-        self.assertDictEqual(bqm.quadratic, quadratic)
+        # Specifically, quadratic biases should not be penalized when encouraging shorter schedules
+        # Note: Unable to simply compare dicts as BQM's quadraticview may re-order dict tuple-keys;
+        #   hence, we're comparing BQM adjacencies.
+        bqm_with_unchanged_quadratic = BinaryQuadraticModel({}, quadratic, 0, vartype)
+        self.assertEqual(bqm.adj, bqm_with_unchanged_quadratic.adj)
 
 
 if __name__ == "__main__":

--- a/job-shop-scheduling/test_job_shop_scheduler.py
+++ b/job-shop-scheduling/test_job_shop_scheduler.py
@@ -12,14 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dimod import ExactSolver, BinaryQuadraticModel
-import dwavebinarycsp as dbc
-from dwavebinarycsp.exceptions import ImpossibleBQM
 from itertools import product
 from re import match
-from tabu import TabuSampler
+import sys
 import unittest
-from unittest.mock import patch
+if sys.version_info.major < 3:
+    from mock import patch
+else:
+    from unittest.mock import patch
+
+from dimod import ExactSolver, BinaryQuadraticModel
+import dwavebinarycsp
+from dwavebinarycsp.exceptions import ImpossibleBQM
+from tabu import TabuSampler
 
 from job_shop_scheduler import JobShopScheduler, get_jss_bqm
 
@@ -447,11 +452,11 @@ class TestGetBqm(unittest.TestCase):
                      ('j2_0,2', 'j2_0,1'): 4.0, ('j2_0,2', 'aux0'): 4.0, ('j2_0,4', 'j2_0,0'): 4.0,
                      ('j2_0,4', 'j2_0,1'): 4.0, ('j2_0,4', 'aux0'): 4.0, ('j2_0,0', 'j2_0,1'): 4.0,
                      ('j2_0,0', 'aux0'): 4.0, ('j2_0,1', 'aux0'): 4.0}
-        vartype = dbc.BINARY
+        vartype = dwavebinarycsp.BINARY
         mock_stitched_bqm = BinaryQuadraticModel(linear, quadratic, 14.0, vartype)
 
         scheduler = JobShopScheduler(jobs)
-        with unittest.mock.patch.object(dbc, "stitch", return_value=mock_stitched_bqm):
+        with patch.object(dwavebinarycsp, "stitch", return_value=mock_stitched_bqm):
             bqm = scheduler.get_bqm()
 
         # Check linear biases


### PR DESCRIPTION
- Remove some unnecessary weights to variables; this should make it easier to gain optimal schedules. Specifically, I was previously encouraging jobs to all finish as quickly as possible. However, that's not necessary for an optimal schedule. So long as the LAST job finishes at the optimal time, I should not care about when the previous jobs finished. At the moment, so long as the job finishes before the lower-bound of the optimal time, the job does not get penalised.
- Some minor code clean up