### PR TITLE
Fix/demo tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,18 +65,23 @@ jobs:
           command: |
             shopt -s extglob
 
+            # Loop through unit tests
+            # Note: failed unit tests are skipped. Return the last failed unit
+            #   test exit code once the loop completes.
+            exit_code=0
             for demo in !($IGNORED_DIRS); do
               if [ -d "$demo" ]; then
-                (
-                  env="envs/$demo"
-                  . "$env/bin/activate"
+                env="envs/$demo"
+                . "$env/bin/activate"
 
-                  cd "$demo"
-                  echo "$demo"
-                  coverage run -m unittest discover
-                )
+                cd "$demo"
+                echo "$demo"
+                coverage run -m unittest discover || exit_code=$?
+                cd ..
               fi
             done
+
+            exit $exit_code
 
   test-3.6:
     <<: *full-test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
               fi
             done
 
-            exit $exit_code
+            exit "$exit_code"
 
   test-3.6:
     <<: *full-test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
                 # wait for tests to finish, collecting the exit status
                 # of the first failing command in the subshell
                 while (( test_status > 128 )); do
-                    wait $pid || test_status=$?
+                    wait $pid && test_status=0 || test_status=$?
                 done
 
                 # accumulate test status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,20 +68,36 @@ jobs:
             # Loop through unit tests
             # Note: failed unit tests are skipped. Return the last failed unit
             #   test exit code once the loop completes.
-            exit_code=0
+
+            declare -i job_status=0
+
             for demo in !($IGNORED_DIRS); do
               if [ -d "$demo" ]; then
-                env="envs/$demo"
-                . "$env/bin/activate"
+                declare -i pid test_status=255
+                
+                # run tests for this demo in bg
+                # subshell exits on first error
+                (
+                  env="envs/$demo"
+                  . "$env/bin/activate"
 
-                cd "$demo"
-                echo "$demo"
-                coverage run -m unittest discover || exit_code=$?
-                cd ..
+                  cd "$demo"
+                  echo "$demo"
+                  coverage run -m unittest discover
+                ) & pid=$!
+                
+                # wait for tests to finish, collecting the exit status
+                # of the first failing command in the subshell
+                while (( test_status > 128 )); do
+                    wait $pid || test_status=$?
+                done
+
+                # accumulate test status
+                (( job_status |= test_status ))
               fi
             done
-
-            exit "$exit_code"
+            
+            exit $job_status
 
   test-3.6:
     <<: *full-test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
             for demo in !($IGNORED_DIRS); do
               if [ -d "$demo" ]; then
                 declare -i pid test_status=255
-                
+
                 # run tests for this demo in bg
                 # subshell exits on first error
                 (
@@ -85,7 +85,7 @@ jobs:
                   echo "$demo"
                   coverage run -m unittest discover
                 ) & pid=$!
-                
+
                 # wait for tests to finish, collecting the exit status
                 # of the first failing command in the subshell
                 while (( test_status > 128 )); do
@@ -93,10 +93,11 @@ jobs:
                 done
 
                 # accumulate test status
-                (( job_status |= test_status ))
+                # (don't fail for zero results in bash -e mode)
+                (( job_status |= test_status )) || true
               fi
             done
-            
+
             exit $job_status
 
   test-3.6:

--- a/maze/test_maze.py
+++ b/maze/test_maze.py
@@ -198,13 +198,15 @@ class TestMazeSolverResponse(unittest.TestCase):
         for key in common_keys:
             if re.match(r'aux\d+$', key):
                 continue
-            self.assertEqual(sample[key], expected[key], "Key {} does not match with expected value".format(key))
+            self.assertAlmostEqual(sample[key], expected[key],
+                                   "Key {} does not match with expected value".format(key))
 
         # Check that non-existent 'sample' variables are 0
         for key in different_keys:
             if re.match(r'aux\d+$', key):
                 continue
-            self.assertEqual(expected[key], 0, "Key {} does not match with expected value".format(key))
+            self.assertEqual(expected[key], 0,
+                             "Key {} does not match with expected value".format(key))
 
     def test_energy_level_one_optimal_path(self):
         # Create maze
@@ -261,8 +263,8 @@ class TestMazeSolverResponse(unittest.TestCase):
         energy_shortest_path1 = get_energy(shortest_path1, bqm)
         energy_shortest_path2 = get_energy(shortest_path2, bqm)
 
-        self.assertEqual(energy_shortest_path0, energy_shortest_path1)
-        self.assertEqual(energy_shortest_path0, energy_shortest_path2)
+        self.assertAlmostEqual(energy_shortest_path0, energy_shortest_path1)
+        self.assertAlmostEqual(energy_shortest_path0, energy_shortest_path2)
 
         # Compare energy level of longer path with shortest path
         longer_path = {'0,1w': 1, '1,1n': 1, '2,1n': 1, '2,2w': 1, '2,2n': 1, '1,3w': 1}

--- a/structural-imbalance/requirements.txt
+++ b/structural-imbalance/requirements.txt
@@ -1,3 +1,4 @@
 dwave-ocean-sdk==1.4.0
 matplotlib==2.2.4
+jsonschema==3.1.1
 scipy


### PR DESCRIPTION
Several minor fixes to the demos repo

1. Allow failed unit tests to be skipped in order for the remaining unit tests to be run. This means that the last bad exit status is stored until after the loop (running the demo tests) completes - by this time, the exit status is then returned.
2. Use `assertalmostequal` for energy comparisons as they're stored in floats
3. Include `jsonschema` in structural-imbalance `requirements.txt`

Note: I'm most concerned about Fix 1 as I'm not sure if it's the best way to deal with the exit code.

