### PR TITLE
Update structural imbalance submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,6 @@
 [submodule "qboost"]
 	path = qboost
 	url = https://github.com/dwave-examples/qboost.git
-[submodule "structural-imbalance"]
-	path = structural-imbalance
-	url = https://github.com/dwave-examples/structural-imbalance.git
 [submodule "sudoku"]
 	path = sudoku
 	url = https://github.com/dwave-examples/sudoku.git
@@ -40,3 +37,6 @@
 [submodule "circuit-fault-diagnosis"]
 	path = circuit-fault-diagnosis
 	url = https://github.com/dwave-examples/circuit-fault-diagnosis.git
+[submodule "structural-imbalance"]
+	path = structural-imbalance
+	url = https://github.com/dwave-examples/structural-imbalance.git


### PR DESCRIPTION
We are currently pointing to a different structural-imbalance repo in dwave-examples. This 'new' structural imbalance repo is the original repo (with the original authors) before it was cloned into a joint repo, dwavesystems/demos